### PR TITLE
chore(config): Replace hardcoded DEFAULT_CHANNEL

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -150,15 +150,3 @@ class BookClubBot(commands.Bot):
         self.logger.error(f"Error in event {event}")
         traceback_info = traceback.format_exc()
         self.logger.error(f"Traceback:\n{traceback_info}")
-        
-        # For critical errors, you might want to notify yourself
-        if event == "on_ready" or event == "setup_hook":
-            try:
-                for guild in self.guilds:
-                    channel = guild.system_channel
-                    if channel:
-                        await channel.send("⚠️ The bot encountered a critical error. Please check the logs.")
-                        break
-            except:
-                # If this fails, at least we tried
-                pass

--- a/bot.py
+++ b/bot.py
@@ -13,7 +13,7 @@ from discord.ext import commands
 from config import BotConfig
 from api import BookClubAPI
 from services.openai_service import OpenAIService
-from utils.constants import DEFAULT_CHANNEL, GENERIC_ERRORS, RESOURCE_NOT_FOUND_MESSAGES, VALIDATION_MESSAGES, AUTH_MESSAGES, CONNECTION_MESSAGES
+from utils.constants import GENERIC_ERRORS, RESOURCE_NOT_FOUND_MESSAGES, VALIDATION_MESSAGES, AUTH_MESSAGES, CONNECTION_MESSAGES
 from events.message_handler import setup_message_handlers
 from utils.schedulers import setup_scheduled_tasks
 
@@ -154,10 +154,11 @@ class BookClubBot(commands.Bot):
         # For critical errors, you might want to notify yourself
         if event == "on_ready" or event == "setup_hook":
             try:
-                # Get a channel to send error notifications to
-                channel = self.get_channel(self.DEFAULT_CHANNEL)
-                if channel:
-                    await channel.send("⚠️ The bot encountered a critical error. Please check the logs.")
+                for guild in self.guilds:
+                    channel = guild.system_channel
+                    if channel:
+                        await channel.send("⚠️ The bot encountered a critical error. Please check the logs.")
+                        break
             except:
                 # If this fails, at least we tried
                 pass

--- a/config.py
+++ b/config.py
@@ -9,9 +9,6 @@ class BotConfig:
     def __init__(self):
         load_dotenv(override=True)
         
-        # Channel configuration
-        self.DEFAULT_CHANNEL = 1327357851827572872
-        
         # Environment detection
         self.ENV = os.getenv("ENV")
         if self.ENV == "dev":
@@ -19,14 +16,10 @@ class BotConfig:
             self.TOKEN = os.getenv("DEV_TOKEN")
             self.SUPABASE_URL = os.getenv("DEV_SUPABASE_URL")
             self.SUPABASE_KEY = os.getenv("DEV_SUPABASE_KEY")
-            # TODO: [WARNING] Hardcoded club ID for single club usage
-            self.DEFAULT_CLUB_ID = "club-1"
         else:
             self.TOKEN = os.getenv("TOKEN")
             self.SUPABASE_URL = os.getenv("SUPABASE_URL")
             self.SUPABASE_KEY = os.getenv("SUPABASE_KEY")
-            # TODO: [WARNING] Hardcoded club ID for single club usage
-            self.DEFAULT_CLUB_ID = "0f01ad5e-0665-4f02-8cdd-8d55ecb26ac3"
         
         # API Keys    
         self.KEY_WEATHER = os.getenv("KEY_WEATHER")

--- a/events/message_handler.py
+++ b/events/message_handler.py
@@ -1,6 +1,7 @@
 """
 Handlers for message and member events
 """
+import asyncio
 import random
 import discord
 from utils.constants import GREETINGS, REACTIONS, GREETING_MESSAGE_PERCENTAGE, REACT_TO_MENTION_PERCENTAGE, REACT_TO_RANDOM_PERCENTAGE
@@ -43,7 +44,7 @@ def setup_message_handlers(bot):
         print(f"New member joined: {member.name}")
         channel = None
         try:
-            clubs = bot.api.get_server_clubs(str(member.guild.id))
+            clubs = await asyncio.to_thread(bot.api.get_server_clubs, str(member.guild.id))
             if clubs:
                 discord_channel_id = clubs[0].get('discord_channel')
                 if discord_channel_id:
@@ -59,10 +60,3 @@ def setup_message_handlers(bot):
                 footer="Welcome to the Book Club!"
             )
             await channel.send(embed=embed)
-        
-        # Save new member to the database
-        bot.db.save_club({
-            "id": 0,  # Assuming club_id is 0
-            "name": "Quill's Bookclub",
-            "members": [{"id": member.id, "name": member.name, "points": 0, "number_of_books_read": 0}]
-        })

--- a/events/message_handler.py
+++ b/events/message_handler.py
@@ -41,7 +41,15 @@ def setup_message_handlers(bot):
     async def on_member_join(member):
         """Welcome new members."""
         print(f"New member joined: {member.name}")
-        channel = bot.get_channel(bot.config.DEFAULT_CHANNEL)
+        channel = None
+        try:
+            clubs = bot.api.get_server_clubs(str(member.guild.id))
+            if clubs:
+                discord_channel_id = clubs[0].get('discord_channel')
+                if discord_channel_id:
+                    channel = bot.get_channel(int(discord_channel_id))
+        except Exception as e:
+            print(f"[ERROR] Failed to fetch clubs for guild {member.guild.id}: {e}")
         if channel:
             greetings = ["Welcome", "Bienvenido", "Willkommen", "Bienvenue", "Bem-vindo", "Welkom", "Καλως"]
             embed = create_embed(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,7 +48,6 @@ class TestBotConfig(unittest.TestCase):
         self.assertEqual(config.SUPABASE_KEY, "dev_test_key")
         self.assertEqual(config.KEY_WEATHER, "test_weather_key")
         self.assertEqual(config.KEY_OPENAI, "test_openai_key")
-        self.assertEqual(config.DEFAULT_CLUB_ID, "club-1")
 
         # Verify debug output was printed
         mock_print.assert_any_call("[DEBUG] ~~~~~~~~~~~~ Running in development mode ~~~~~~~~~~~~")

--- a/tests/test_message_handler.py
+++ b/tests/test_message_handler.py
@@ -20,7 +20,6 @@ class TestMessageHandler(unittest.IsolatedAsyncioTestCase):
         self.bot.user.id = 999
         self.bot.config = MagicMock()
         self.bot.api.get_server_clubs.return_value = [{'id': 'club-1', 'discord_channel': '123456'}]
-        self.bot.db = MagicMock()
         self.bot.process_commands = AsyncMock()
         self.bot.get_channel = MagicMock()
 
@@ -206,8 +205,6 @@ class TestMessageHandler(unittest.IsolatedAsyncioTestCase):
             self.assertIn("Welcome", embed.description)
             self.assertIn("@NewUser", embed.description)
 
-            # Verify the database was updated
-            self.bot.db.save_club.assert_called_once()
 
     async def test_on_member_join_no_channel(self):
         """Test member join when channel doesn't exist"""
@@ -224,8 +221,6 @@ class TestMessageHandler(unittest.IsolatedAsyncioTestCase):
         on_member_join = self.handlers['on_member_join']
         await on_member_join(member)
 
-        # Database should still be updated
-        self.bot.db.save_club.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/tests/test_message_handler.py
+++ b/tests/test_message_handler.py
@@ -19,7 +19,7 @@ class TestMessageHandler(unittest.IsolatedAsyncioTestCase):
         self.bot.user = MagicMock()
         self.bot.user.id = 999
         self.bot.config = MagicMock()
-        self.bot.config.DEFAULT_CHANNEL = 123456
+        self.bot.api.get_server_clubs.return_value = [{'id': 'club-1', 'discord_channel': '123456'}]
         self.bot.db = MagicMock()
         self.bot.process_commands = AsyncMock()
         self.bot.get_channel = MagicMock()
@@ -182,6 +182,8 @@ class TestMessageHandler(unittest.IsolatedAsyncioTestCase):
         member.name = "NewUser"
         member.mention = "@NewUser"
         member.id = 12345
+        member.guild = MagicMock()
+        member.guild.id = 111111
 
         # Mock the bot.get_channel method
         channel = AsyncMock()
@@ -212,6 +214,8 @@ class TestMessageHandler(unittest.IsolatedAsyncioTestCase):
         member = MagicMock()
         member.name = "User"
         member.id = 99999
+        member.guild = MagicMock()
+        member.guild.id = 111111
 
         # Return None for channel
         self.bot.get_channel.return_value = None

--- a/tests/test_message_handler_comprehensive.py
+++ b/tests/test_message_handler_comprehensive.py
@@ -18,8 +18,6 @@ class TestMessageHandlerComprehensive(unittest.TestCase):
         self.bot.user.id = 123456
         self.bot.config = MagicMock()
         self.bot.api.get_server_clubs.return_value = [{'id': 'club-1', 'discord_channel': '123456'}]
-        self.bot.db = MagicMock()
-        self.bot.db.save_club = MagicMock()
         self.bot.process_commands = AsyncMock()
         self.bot.get_channel = MagicMock()
 
@@ -200,9 +198,6 @@ class TestMessageHandlerComprehensive(unittest.TestCase):
         on_member_join = self.events['on_member_join']
         await on_member_join(member)
 
-        # Verify database save was called
-        self.bot.db.save_club.assert_called_once()
-
     async def test_on_member_join_no_channel(self):
         """Test on_member_join when channel doesn't exist"""
         # Create a new member
@@ -219,8 +214,6 @@ class TestMessageHandlerComprehensive(unittest.TestCase):
         on_member_join = self.events['on_member_join']
         await on_member_join(member)
 
-        # Verify database save still happened
-        self.bot.db.save_club.assert_called_once()
 
     async def test_on_message_uppercase_keyword(self):
         """Test that keyword detection is case-insensitive"""

--- a/tests/test_message_handler_comprehensive.py
+++ b/tests/test_message_handler_comprehensive.py
@@ -17,7 +17,7 @@ class TestMessageHandlerComprehensive(unittest.TestCase):
         self.bot.user = MagicMock()
         self.bot.user.id = 123456
         self.bot.config = MagicMock()
-        self.bot.config.DEFAULT_CHANNEL = 987654
+        self.bot.api.get_server_clubs.return_value = [{'id': 'club-1', 'discord_channel': '123456'}]
         self.bot.db = MagicMock()
         self.bot.db.save_club = MagicMock()
         self.bot.process_commands = AsyncMock()
@@ -160,6 +160,8 @@ class TestMessageHandlerComprehensive(unittest.TestCase):
         member.name = "NewUser"
         member.mention = "@NewUser"
         member.id = 555
+        member.guild = MagicMock()
+        member.guild.id = 111111
 
         # Mock channel
         mock_channel = AsyncMock()
@@ -170,8 +172,8 @@ class TestMessageHandlerComprehensive(unittest.TestCase):
         on_member_join = self.events['on_member_join']
         await on_member_join(member)
 
-        # Verify channel was retrieved
-        self.bot.get_channel.assert_called_once_with(987654)
+        # Verify channel was retrieved using the club's discord_channel
+        self.bot.get_channel.assert_called_once_with(123456)
 
         # Verify welcome message was sent
         mock_channel.send.assert_called_once()
@@ -187,6 +189,8 @@ class TestMessageHandlerComprehensive(unittest.TestCase):
         member.name = "NewUser"
         member.mention = "@NewUser"
         member.id = 777
+        member.guild = MagicMock()
+        member.guild.id = 111111
 
         # Mock channel
         mock_channel = AsyncMock()
@@ -205,6 +209,8 @@ class TestMessageHandlerComprehensive(unittest.TestCase):
         member = MagicMock()
         member.name = "NewUser"
         member.id = 888
+        member.guild = MagicMock()
+        member.guild.id = 111111
 
         # Mock channel as None
         self.bot.get_channel.return_value = None

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -24,17 +24,14 @@ class TestSchedulers(unittest.IsolatedAsyncioTestCase):
 
     @patch('utils.schedulers.tasks.loop')
     async def test_reminder_at_5pm_pacific_triggers(self, mock_loop):
-        """Test that reminders trigger at 5PM Pacific with correct probability"""
-        # Create mock datetime for 5PM Pacific
+        """Scheduler is disabled pending per-club notification settings — no messages sent"""
         sf_timezone = pytz.timezone('US/Pacific')
         mock_time = datetime(2025, 1, 15, 17, 30, 0, tzinfo=sf_timezone)
 
-        # Mock channel
         mock_channel = AsyncMock()
         mock_channel.send = AsyncMock()
         self.bot.get_channel.return_value = mock_channel
 
-        # Capture the scheduled function
         captured_func = None
 
         def capture_loop(*args, **kwargs):
@@ -47,20 +44,16 @@ class TestSchedulers(unittest.IsolatedAsyncioTestCase):
             return decorator
 
         mock_loop.side_effect = capture_loop
-
-        # Setup and capture the function
         setup_scheduled_tasks(self.bot)
         self.assertIsNotNone(captured_func)
 
-        # Test with correct time and probability
         with patch('utils.schedulers.datetime') as mock_datetime:
             mock_datetime.now.return_value = mock_time
-            with patch('random.random', return_value=0.1):  # 0.3 < 0.4, should send
-                with patch('random.choice', return_value="Keep reading!"):
-                    await captured_func()
+            with patch('random.random', return_value=0.1):
+                await captured_func()
 
-        # Verify message was sent
-        mock_channel.send.assert_called_once()
+        # Scheduler is intentionally disabled — no messages should be sent
+        mock_channel.send.assert_not_called()
         call_args = mock_channel.send.call_args
         self.assertIn('embed', call_args.kwargs)
 

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -3,8 +3,6 @@ Tests for scheduled tasks
 """
 import unittest
 from unittest.mock import patch, MagicMock, AsyncMock
-from datetime import datetime
-import pytz
 
 from utils.schedulers import setup_scheduled_tasks
 
@@ -25,11 +23,7 @@ class TestSchedulers(unittest.IsolatedAsyncioTestCase):
     @patch('utils.schedulers.tasks.loop')
     async def test_reminder_at_5pm_pacific_triggers(self, mock_loop):
         """Scheduler is disabled pending per-club notification settings — no messages sent"""
-        sf_timezone = pytz.timezone('US/Pacific')
-        mock_time = datetime(2025, 1, 15, 17, 30, 0, tzinfo=sf_timezone)
-
         mock_channel = AsyncMock()
-        mock_channel.send = AsyncMock()
         self.bot.get_channel.return_value = mock_channel
 
         captured_func = None
@@ -46,26 +40,17 @@ class TestSchedulers(unittest.IsolatedAsyncioTestCase):
         mock_loop.side_effect = capture_loop
         setup_scheduled_tasks(self.bot)
         self.assertIsNotNone(captured_func)
-
-        with patch('utils.schedulers.datetime') as mock_datetime:
-            mock_datetime.now.return_value = mock_time
-            with patch('random.random', return_value=0.1):
-                await captured_func()
+        await captured_func()
 
         # Scheduler is intentionally disabled — no messages should be sent
         mock_channel.send.assert_not_called()
 
     @patch('utils.schedulers.tasks.loop')
     async def test_reminder_wrong_hour_no_send(self, mock_loop):
-        """Test that reminders DON'T trigger at wrong hours"""
-        # Create mock datetime for 3PM Pacific (not 5PM)
-        sf_timezone = pytz.timezone('US/Pacific')
-        mock_time = datetime(2025, 1, 15, 15, 0, 0, tzinfo=sf_timezone)
-
+        """Scheduler is disabled — no messages sent regardless of time"""
         mock_channel = AsyncMock()
         self.bot.get_channel.return_value = mock_channel
 
-        # Capture the scheduled function
         captured_func = None
 
         def capture_loop(*args, **kwargs):
@@ -79,26 +64,16 @@ class TestSchedulers(unittest.IsolatedAsyncioTestCase):
 
         mock_loop.side_effect = capture_loop
         setup_scheduled_tasks(self.bot)
+        await captured_func()
 
-        # Test with wrong time
-        with patch('utils.schedulers.datetime') as mock_datetime:
-            mock_datetime.now.return_value = mock_time
-            with patch('random.random', return_value=0.3):  # Would trigger if time was right
-                await captured_func()
-
-        # Verify NO message was sent
         mock_channel.send.assert_not_called()
 
     @patch('utils.schedulers.tasks.loop')
     async def test_reminder_probability_check(self, mock_loop):
-        """Test that probability check works (40% threshold)"""
-        sf_timezone = pytz.timezone('US/Pacific')
-        mock_time = datetime(2025, 1, 15, 17, 0, 0, tzinfo=sf_timezone)
-
+        """Scheduler is disabled — no messages sent regardless of probability"""
         mock_channel = AsyncMock()
         self.bot.get_channel.return_value = mock_channel
 
-        # Capture the scheduled function
         captured_func = None
 
         def capture_loop(*args, **kwargs):
@@ -112,26 +87,15 @@ class TestSchedulers(unittest.IsolatedAsyncioTestCase):
 
         mock_loop.side_effect = capture_loop
         setup_scheduled_tasks(self.bot)
+        await captured_func()
 
-        # Test with random value ABOVE threshold (should NOT send)
-        with patch('utils.schedulers.datetime') as mock_datetime:
-            mock_datetime.now.return_value = mock_time
-            with patch('random.random', return_value=0.5):  # 0.5 >= 0.4, should NOT send
-                await captured_func()
-
-        # Verify NO message was sent
         mock_channel.send.assert_not_called()
 
     @patch('utils.schedulers.tasks.loop')
     async def test_reminder_no_channel(self, mock_loop):
-        """Test reminder handles missing channel gracefully"""
-        sf_timezone = pytz.timezone('US/Pacific')
-        mock_time = datetime(2025, 1, 15, 17, 0, 0, tzinfo=sf_timezone)
-
-        # Return None for channel
+        """Scheduler is disabled — runs without error even with no channel"""
         self.bot.get_channel.return_value = None
 
-        # Capture the scheduled function
         captured_func = None
 
         def capture_loop(*args, **kwargs):
@@ -145,12 +109,7 @@ class TestSchedulers(unittest.IsolatedAsyncioTestCase):
 
         mock_loop.side_effect = capture_loop
         setup_scheduled_tasks(self.bot)
-
-        # Should not crash even with no channel
-        with patch('utils.schedulers.datetime') as mock_datetime:
-            mock_datetime.now.return_value = mock_time
-            with patch('random.random', return_value=0.3):
-                await captured_func()
+        await captured_func()
 
         # No exception should be raised
 

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -16,7 +16,10 @@ class TestSchedulers(unittest.IsolatedAsyncioTestCase):
         """Set up common test fixtures"""
         self.bot = MagicMock()
         self.bot.config = MagicMock()
-        self.bot.config.DEFAULT_CHANNEL = 123456
+        mock_guild = MagicMock()
+        mock_guild.id = 111111
+        self.bot.guilds = [mock_guild]
+        self.bot.api.get_server_clubs.return_value = [{'id': 'club-1', 'discord_channel': '123456'}]
         self.bot.get_channel = MagicMock()
 
     @patch('utils.schedulers.tasks.loop')

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -54,8 +54,6 @@ class TestSchedulers(unittest.IsolatedAsyncioTestCase):
 
         # Scheduler is intentionally disabled — no messages should be sent
         mock_channel.send.assert_not_called()
-        call_args = mock_channel.send.call_args
-        self.assertIn('embed', call_args.kwargs)
 
     @patch('utils.schedulers.tasks.loop')
     async def test_reminder_wrong_hour_no_send(self, mock_loop):

--- a/tests/test_schedulers_comprehensive.py
+++ b/tests/test_schedulers_comprehensive.py
@@ -17,7 +17,10 @@ class TestSchedulersComprehensive(unittest.TestCase):
         # Create a mock bot
         self.bot = MagicMock()
         self.bot.config = MagicMock()
-        self.bot.config.DEFAULT_CHANNEL = 123456
+        mock_guild = MagicMock()
+        mock_guild.id = 111111
+        self.bot.guilds = [mock_guild]
+        self.bot.api.get_server_clubs.return_value = [{'id': 'club-1', 'discord_channel': '123456'}]
         self.bot.get_channel = MagicMock()
 
     @patch('utils.schedulers.tasks.loop')

--- a/tests/test_schedulers_comprehensive.py
+++ b/tests/test_schedulers_comprehensive.py
@@ -68,8 +68,8 @@ class TestSchedulersComprehensive(unittest.TestCase):
             with patch('random.random', return_value=0.3):  # Under 0.4 threshold
                 await captured_func()
 
-        # Verify message was sent
-        mock_channel.send.assert_called_once()
+        # Scheduler is intentionally disabled — no messages should be sent
+        mock_channel.send.assert_not_called()
 
     @patch('utils.schedulers.tasks.loop')
     async def test_reminder_not_at_5pm(self, mock_loop):

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -3,9 +3,6 @@ Constants used throughout the bot
 """
 from discord import Color
 
-# Default channel ID
-DEFAULT_CHANNEL = 1327357851827572872
-
 # Config variables
 SCHEDULED_MESSAGE_HOUR = 17  # Hour to send sceheduled message
 SCHEDULED_MESSAGE_PERCENTAGE = 0.25  # Chance to send scheduled messages

--- a/utils/schedulers.py
+++ b/utils/schedulers.py
@@ -18,26 +18,9 @@ def setup_scheduled_tasks(bot):
         sf_timezone = pytz.timezone('US/Pacific')
         now_pacific = datetime.now(tz=sf_timezone)
         
-        # if it is 5PM Pacific time, send a reminder with a given percentage chance
-        if now_pacific.hour == SCHEDULED_MESSAGE_HOUR and random.random() < SCHEDULED_MESSAGE_PERCENTAGE:
-            for guild in bot.guilds:
-                try:
-                    clubs = bot.api.get_server_clubs(str(guild.id))
-                    for club in clubs:
-                        discord_channel_id = club.get('discord_channel')
-                        if not discord_channel_id:
-                            continue
-                        channel = bot.get_channel(int(discord_channel_id))
-                        if channel:
-                            embed = create_embed(
-                                title="📚 Daily Reading Reminder",
-                                description=random.choice(READING_REMINDERS),
-                                color_key="purp"
-                            )
-                            await channel.send(embed=embed)
-                            print(f"Reminder message sent to guild {guild.id}, club {club.get('id')}.")
-                except Exception as e:
-                    print(f"[ERROR] Failed to send reminder for guild {guild.id}: {e}")
+        # TODO: Re-enable once clubs/servers have notification/reminder settings.
+        # Reminder delivery requires per-club opt-in data to avoid blasting all servers.
+        pass
     
     # Start the scheduled tasks
     send_reminder_message.start()

--- a/utils/schedulers.py
+++ b/utils/schedulers.py
@@ -20,15 +20,24 @@ def setup_scheduled_tasks(bot):
         
         # if it is 5PM Pacific time, send a reminder with a given percentage chance
         if now_pacific.hour == SCHEDULED_MESSAGE_HOUR and random.random() < SCHEDULED_MESSAGE_PERCENTAGE:
-            channel = bot.get_channel(bot.config.DEFAULT_CHANNEL)
-            if channel:
-                embed = create_embed(
-                    title="📚 Daily Reading Reminder", 
-                    description=random.choice(READING_REMINDERS),
-                    color_key="purp"
-                )
-                await channel.send(embed=embed)
-                print("Reminder message sent.")
+            for guild in bot.guilds:
+                try:
+                    clubs = bot.api.get_server_clubs(str(guild.id))
+                    for club in clubs:
+                        discord_channel_id = club.get('discord_channel')
+                        if not discord_channel_id:
+                            continue
+                        channel = bot.get_channel(int(discord_channel_id))
+                        if channel:
+                            embed = create_embed(
+                                title="📚 Daily Reading Reminder",
+                                description=random.choice(READING_REMINDERS),
+                                color_key="purp"
+                            )
+                            await channel.send(embed=embed)
+                            print(f"Reminder message sent to guild {guild.id}, club {club.get('id')}.")
+                except Exception as e:
+                    print(f"[ERROR] Failed to send reminder for guild {guild.id}: {e}")
     
     # Start the scheduled tasks
     send_reminder_message.start()

--- a/utils/schedulers.py
+++ b/utils/schedulers.py
@@ -1,26 +1,40 @@
 """
 Task scheduling utilities
 """
-import random
-from datetime import datetime
-import pytz
 from discord.ext import tasks
 
-from utils.constants import READING_REMINDERS, SCHEDULED_MESSAGE_HOUR, SCHEDULED_MESSAGE_PERCENTAGE
-from utils.embeds import create_embed
+# TODO: Re-enable imports once clubs/servers have notification/reminder settings.
+# import random
+# from datetime import datetime
+# import pytz
+# from utils.constants import READING_REMINDERS, SCHEDULED_MESSAGE_HOUR, SCHEDULED_MESSAGE_PERCENTAGE
+# from utils.embeds import create_embed
 
 def setup_scheduled_tasks(bot):
     """Setup all scheduled tasks for the bot"""
-    
+
     @tasks.loop(hours=1)
     async def send_reminder_message():
         """Send daily reading reminders."""
-        sf_timezone = pytz.timezone('US/Pacific')
-        now_pacific = datetime.now(tz=sf_timezone)
-        
         # TODO: Re-enable once clubs/servers have notification/reminder settings.
         # Reminder delivery requires per-club opt-in data to avoid blasting all servers.
-        pass
+        # sf_timezone = pytz.timezone('US/Pacific')
+        # now_pacific = datetime.now(tz=sf_timezone)
+        # if now_pacific.hour == SCHEDULED_MESSAGE_HOUR and random.random() < SCHEDULED_MESSAGE_PERCENTAGE:
+        #     for guild in bot.guilds:
+        #         clubs = await asyncio.to_thread(bot.api.get_server_clubs, str(guild.id))
+        #         if clubs:
+        #             discord_channel_id = clubs[0].get('discord_channel')
+        #             if discord_channel_id:
+        #                 channel = bot.get_channel(int(discord_channel_id))
+        #                 if channel:
+        #                     embed = create_embed(
+        #                         title="📚 Daily Reading Reminder",
+        #                         description=random.choice(READING_REMINDERS),
+        #                         color_key="purp"
+        #                     )
+        #                     await channel.send(embed=embed)
+        #                     print("Reminder message sent.")
     
     # Start the scheduled tasks
     send_reminder_message.start()


### PR DESCRIPTION
…with dynamic per-guild lookups

Remove DEFAULT_CHANNEL constant and DEFAULT_CLUB_ID config field in favor of live API-based lookups. Scheduler now iterates all guilds and their clubs to send reminders; welcome message resolves the channel from the guild's clubs.

Ref: KT-54