### PR TITLE
feat(admin): Implement admin prefix commands with role-based access

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,4 +8,9 @@
     ],
     "python.testing.pytestEnabled": false,
     "python.testing.unittestEnabled": true,
+    "files.exclude": {
+        "**/__pycache__": true,
+        "**/*.egg-info": true,
+        "**/.pytest_cache": true
+    }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This document provides comprehensive context about the Kluvs Discord bot for AI 
 **Language:** Python 3.9+
 **Architecture:** Modular command-based bot with external API integration
 **Current Version:** 0.0.1
-**Repository:** https://github.com/ivangarzab/quill-bot.git
+**Repository:** https://github.com/kluvs-api/quill-bot.git
 
 ### Purpose
 
@@ -480,5 +480,5 @@ The bot communicates with a Supabase backend via Edge Functions (serverless):
 
 ### Contact
 **Maintainer:** Ivan Garza (ivangb6@gmail.com)
-**Repository:** https://github.com/ivangarzab/quill-bot.git
+**Repository:** https://github.com/kluvs-api/quill-bot.git
 **Discord Install:** https://discord.com/oauth2/authorize?client_id=1327910712454152275

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kluvs - Discord bot
 
-[![Tests](https://github.com/ivangarzab/kluvs-bot/workflows/Run%20Tests/badge.svg)](https://github.com/ivangarzab/kluvs-bot/actions)
-[![codecov](https://codecov.io/gh/ivangarzab/kluvs-bot/branch/main/graph/badge.svg)](https://codecov.io/gh/ivangarzab/kluvs-bot)
+[![Tests](https://github.com/kluvs-api/kluvs-bot/workflows/Run%20Tests/badge.svg)](https://github.com/kluvs-api/kluvs-bot/actions)
+[![codecov](https://codecov.io/gh/kluvs-api/kluvs-bot/branch/main/graph/badge.svg)](https://codecov.io/gh/kluvs-api/kluvs-bot)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![Discord.py](https://img.shields.io/badge/discord.py-latest-blue.svg)](https://github.com/Rapptz/discord.py)
 
@@ -88,7 +88,7 @@ Quill has a friendly librarian personality with:
 
 1. **Clone the repository:**
    ```bash
-   git clone https://github.com/ivangarzab/quill-bot.git
+   git clone https://github.com/kluvs-api/kluvs-bot.git
    cd quill-bot
    ```
 
@@ -133,7 +133,7 @@ Quill has a friendly librarian personality with:
 
 1. **Clone the repository:**
    ```bash
-   git clone https://github.com/ivangarzab/quill-bot.git
+   git clone https://github.com/kluvs-api/kluvs-bot.git
    cd quill-bot
    ```
 
@@ -305,7 +305,7 @@ This project is currently unlicensed. See [TERMS.md](TERMS.md) for usage terms.
 
 **Maintainer:** Ivan Garza
 **Email:** ivangb6@gmail.com
-**Repository:** https://github.com/ivangarzab/quill-bot.git
+**Repository:** https://github.com/kluvs-api/kluvs-bot.git
 
 ## Acknowledgments
 

--- a/api/bookclub_api.py
+++ b/api/bookclub_api.py
@@ -439,6 +439,34 @@ class BookClubAPI:
         except requests.exceptions.RequestException as e:
             self._handle_request_error(e, "member", str(member_id))
     
+    def get_member_by_discord_id(self, discord_id: str) -> Optional[Dict]:
+        """
+        Get a member by their Discord user ID.
+        Returns None if no member is found instead of raising an exception.
+
+        Args:
+            discord_id: The Discord user snowflake ID
+
+        Returns:
+            Dict containing member details including clubs, or None if not found
+
+        Raises:
+            AuthenticationError: If there's an authentication issue
+            APIError: For other API errors (but not ResourceNotFoundError)
+        """
+        url = f"{self.functions_url}/member"
+        params = {"discord_id": discord_id}
+
+        try:
+            response = requests.get(url, headers=self.headers, params=params)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            try:
+                self._handle_request_error(e, "member", discord_id)
+            except ResourceNotFoundError:
+                return None
+
     def create_member(self, member_data: Dict) -> Dict:
         """
         Create a new member.

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -22,8 +22,10 @@ def setup_admin_commands(bot):
         """Returns True if the command author is the Discord guild owner."""
         return ctx.author == ctx.guild.owner
 
-    async def _check_club_admin(ctx):
-        """Returns True if the author has admin or owner role in the club for this channel."""
+    async def _can_manage_clubs(ctx):
+        """Returns True if user is guild owner OR club admin in the current channel's club."""
+        if _check_guild_owner(ctx):
+            return True
         guild_id = str(ctx.guild.id)
         channel_id = str(ctx.channel.id)
         club_data = bot.api.find_club_in_channel(channel_id, guild_id)
@@ -163,7 +165,7 @@ def setup_admin_commands(bot):
         Creates a new book club linked to the current channel.
         Usage: !club_create <name>
         """
-        if not await _check_club_admin(ctx):
+        if not await _can_manage_clubs(ctx):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         try:
@@ -186,7 +188,7 @@ def setup_admin_commands(bot):
         Updates club details. Provide at least one flag.
         Usage: !club_update [--name <name>] [--channel <channel_id>]
         """
-        if not await _check_club_admin(ctx):
+        if not await _can_manage_clubs(ctx):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         guild_id = str(ctx.guild.id)
@@ -221,7 +223,7 @@ def setup_admin_commands(bot):
         Deletes the book club linked to the current channel.
         Usage: !club_delete
         """
-        if not await _check_club_admin(ctx):
+        if not await _can_manage_clubs(ctx):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         guild_id = str(ctx.guild.id)
@@ -256,7 +258,7 @@ def setup_admin_commands(bot):
         Adds a mentioned Discord user to the book club in this channel.
         Usage: !member_add @User
         """
-        if not await _check_club_admin(ctx):
+        if not await _can_manage_clubs(ctx):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         guild_id = str(ctx.guild.id)
@@ -285,7 +287,7 @@ def setup_admin_commands(bot):
         Removes a member by their ID.
         Usage: !member_remove <member_id>
         """
-        if not await _check_club_admin(ctx):
+        if not await _can_manage_clubs(ctx):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         confirmed = await _confirm(
@@ -313,7 +315,7 @@ def setup_admin_commands(bot):
         Sets a member's role to admin or member.
         Usage: !member_role <member_id> <admin|member>
         """
-        if not await _check_club_admin(ctx):
+        if not await _can_manage_clubs(ctx):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         if role not in ("admin", "member"):
@@ -343,7 +345,7 @@ def setup_admin_commands(bot):
         Creates a reading session for the club in this channel.
         Usage: !session_create "<book title>" <author>
         """
-        if not await _check_club_admin(ctx):
+        if not await _can_manage_clubs(ctx):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         guild_id = str(ctx.guild.id)
@@ -371,7 +373,7 @@ def setup_admin_commands(bot):
         Updates the active session. Provide at least one flag.
         Usage: !session_update [--due-date YYYY-MM-DD] [--book "<title>|<author>"]
         """
-        if not await _check_club_admin(ctx):
+        if not await _can_manage_clubs(ctx):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         guild_id = str(ctx.guild.id)
@@ -412,7 +414,7 @@ def setup_admin_commands(bot):
         Deletes the active session for the club in this channel.
         Usage: !session_delete
         """
-        if not await _check_club_admin(ctx):
+        if not await _can_manage_clubs(ctx):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         guild_id = str(ctx.guild.id)

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -1,5 +1,5 @@
 """
-Admin commands (verison)
+Admin commands (version, server, club, member, session management)
 """
 import re
 import os
@@ -7,6 +7,8 @@ import discord
 from discord.ext import commands
 
 from utils.embeds import create_embed
+from api.bookclub_api import APIError
+
 
 def setup_admin_commands(bot):
     """
@@ -15,6 +17,39 @@ def setup_admin_commands(bot):
     Args:
         bot: The bot instance
     """
+
+    def _check_guild_owner(ctx):
+        """Returns True if the command author is the Discord guild owner."""
+        return ctx.author == ctx.guild.owner
+
+    async def _check_club_admin(ctx):
+        """Returns True if the author has admin or owner role in the club for this channel."""
+        guild_id = str(ctx.guild.id)
+        channel_id = str(ctx.channel.id)
+        club_data = bot.api.find_club_in_channel(channel_id, guild_id)
+        if not club_data:
+            return False
+        for member in club_data.get("members", []):
+            if str(member.get("discord_id")) == str(ctx.author.id):
+                return member.get("role") in ("admin", "owner")
+        return False
+
+    async def _confirm(ctx, prompt):
+        """Sends a y/n prompt; returns True only if the user replies 'y' within 30 seconds."""
+        await ctx.send(prompt)
+
+        def check(m):
+            return m.author == ctx.author and m.channel == ctx.channel
+
+        try:
+            msg = await bot.wait_for("message", timeout=30.0, check=check)
+            return msg.content.strip().lower() == "y"
+        except TimeoutError:
+            await ctx.send("⏰ Confirmation timed out. Action cancelled.")
+            return False
+
+    # ── Version ──────────────────────────────────────────────────────────────
+
     @bot.command(name="version", help="Shows the current version of the bot")
     async def version(ctx: commands.Context):
         """
@@ -22,28 +57,20 @@ def setup_admin_commands(bot):
         Usage: !version
         """
         try:
-            # Find setup.py in the project root directory
             setup_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "setup.py")
-
-            # Read the setup.py file
             with open(setup_path, "r") as file:
                 setup_content = file.read()
-            
-            # Extract version using regex
+
             version_match = re.search(r'version\s*=\s*["\']([^"\']+)["\']', setup_content)
-            
             if version_match:
-                version = version_match.group(1)
-                
-                # Create and send a pretty embed
+                v = version_match.group(1)
                 embed = create_embed(
-                    title=f"📚 Quill Bot version: v{version}",
+                    title=f"📚 Quill Bot version: v{v}",
                     color_key="blank",
                     timestamp=True
                 )
                 await ctx.send(embed=embed)
             else:
-                # Send error embed if version not found
                 embed = create_embed(
                     title="❌ Error",
                     description="Couldn't find version information in setup.py",
@@ -51,10 +78,364 @@ def setup_admin_commands(bot):
                 )
                 await ctx.send(embed=embed)
         except Exception as e:
-            # Send error embed for any exceptions
             embed = create_embed(
                 title="❌ Error",
                 description=f"Error retrieving version: {str(e)}",
                 color_key="error"
             )
             await ctx.send(embed=embed)
+
+    # ── Server commands (guild owner only) ───────────────────────────────────
+
+    @bot.command(name="server_register", help="Register this Discord server with the bot")
+    async def server_register(ctx: commands.Context):
+        """
+        Registers the Discord server.
+        Usage: !server_register
+        """
+        if not _check_guild_owner(ctx):
+            await ctx.send("❌ Only the server owner can use this command.")
+            return
+        try:
+            bot.api.register_server(str(ctx.guild.id), ctx.guild.name)
+            embed = create_embed(
+                title="✅ Server Registered",
+                description=f"**{ctx.guild.name}** has been registered.",
+                color_key="success"
+            )
+            await ctx.send(embed=embed)
+        except APIError as e:
+            await ctx.send(f"❌ Failed to register server: {e}")
+
+    @bot.command(name="server_update", help="Update this server's registered name")
+    async def server_update(ctx: commands.Context, *, name: str):
+        """
+        Updates the server's registered name.
+        Usage: !server_update <name>
+        """
+        if not _check_guild_owner(ctx):
+            await ctx.send("❌ Only the server owner can use this command.")
+            return
+        try:
+            bot.api.update_server(str(ctx.guild.id), name)
+            embed = create_embed(
+                title="✅ Server Updated",
+                description=f"Server name updated to **{name}**.",
+                color_key="success"
+            )
+            await ctx.send(embed=embed)
+        except APIError as e:
+            await ctx.send(f"❌ Failed to update server: {e}")
+
+    @bot.command(name="server_delete", help="Delete this server's registration")
+    async def server_delete(ctx: commands.Context):
+        """
+        Deletes the server registration and all associated data.
+        Usage: !server_delete
+        """
+        if not _check_guild_owner(ctx):
+            await ctx.send("❌ Only the server owner can use this command.")
+            return
+        confirmed = await _confirm(
+            ctx,
+            "⚠️ This will delete **all server data** including clubs, members, and sessions. "
+            "Type `y` to confirm or anything else to cancel."
+        )
+        if not confirmed:
+            await ctx.send("Action cancelled.")
+            return
+        try:
+            bot.api.delete_server(str(ctx.guild.id))
+            embed = create_embed(
+                title="✅ Server Deleted",
+                description="Server registration and all associated data have been removed.",
+                color_key="success"
+            )
+            await ctx.send(embed=embed)
+        except APIError as e:
+            await ctx.send(f"❌ Failed to delete server: {e}")
+
+    # ── Club commands (club admin+) ───────────────────────────────────────────
+
+    @bot.command(name="club_create", help="Create a new book club in this channel")
+    async def club_create(ctx: commands.Context, *, name: str):
+        """
+        Creates a new book club linked to the current channel.
+        Usage: !club_create <name>
+        """
+        if not await _check_club_admin(ctx):
+            await ctx.send("❌ You need to be a club admin or owner to use this command.")
+            return
+        try:
+            bot.api.create_club(
+                {"name": name, "discord_channel": str(ctx.channel.id)},
+                str(ctx.guild.id)
+            )
+            embed = create_embed(
+                title="✅ Club Created",
+                description=f"Book club **{name}** created in this channel.",
+                color_key="success"
+            )
+            await ctx.send(embed=embed)
+        except APIError as e:
+            await ctx.send(f"❌ Failed to create club: {e}")
+
+    @bot.command(name="club_update", help="Update the club name or channel")
+    async def club_update(ctx: commands.Context, *, args: str):
+        """
+        Updates club details. Provide at least one flag.
+        Usage: !club_update [--name <name>] [--channel <channel_id>]
+        """
+        if not await _check_club_admin(ctx):
+            await ctx.send("❌ You need to be a club admin or owner to use this command.")
+            return
+        guild_id = str(ctx.guild.id)
+        club_data = bot.api.find_club_in_channel(str(ctx.channel.id), guild_id)
+        if not club_data:
+            await ctx.send("❌ No book club found in this channel.")
+            return
+        update = {}
+        name_match = re.search(r'--name\s+(.+?)(?:\s+--|$)', args)
+        channel_match = re.search(r'--channel\s+(\S+)', args)
+        if name_match:
+            update["name"] = name_match.group(1).strip()
+        if channel_match:
+            update["discord_channel"] = channel_match.group(1).strip()
+        if not update:
+            await ctx.send("❌ Provide at least `--name <name>` or `--channel <channel_id>`.")
+            return
+        try:
+            bot.api.update_club(club_data["id"], update, guild_id)
+            embed = create_embed(
+                title="✅ Club Updated",
+                description="Club details updated successfully.",
+                color_key="success"
+            )
+            await ctx.send(embed=embed)
+        except APIError as e:
+            await ctx.send(f"❌ Failed to update club: {e}")
+
+    @bot.command(name="club_delete", help="Delete the book club in this channel")
+    async def club_delete(ctx: commands.Context):
+        """
+        Deletes the book club linked to the current channel.
+        Usage: !club_delete
+        """
+        if not await _check_club_admin(ctx):
+            await ctx.send("❌ You need to be a club admin or owner to use this command.")
+            return
+        guild_id = str(ctx.guild.id)
+        club_data = bot.api.find_club_in_channel(str(ctx.channel.id), guild_id)
+        if not club_data:
+            await ctx.send("❌ No book club found in this channel.")
+            return
+        confirmed = await _confirm(
+            ctx,
+            f"⚠️ This will delete **{club_data['name']}** and all its data. "
+            "Type `y` to confirm or anything else to cancel."
+        )
+        if not confirmed:
+            await ctx.send("Action cancelled.")
+            return
+        try:
+            bot.api.delete_club(club_data["id"], guild_id)
+            embed = create_embed(
+                title="✅ Club Deleted",
+                description=f"**{club_data['name']}** has been deleted.",
+                color_key="success"
+            )
+            await ctx.send(embed=embed)
+        except APIError as e:
+            await ctx.send(f"❌ Failed to delete club: {e}")
+
+    # ── Member commands (club admin+) ─────────────────────────────────────────
+
+    @bot.command(name="member_add", help="Add a Discord user to the book club")
+    async def member_add(ctx: commands.Context, member: discord.Member):
+        """
+        Adds a mentioned Discord user to the book club in this channel.
+        Usage: !member_add @User
+        """
+        if not await _check_club_admin(ctx):
+            await ctx.send("❌ You need to be a club admin or owner to use this command.")
+            return
+        guild_id = str(ctx.guild.id)
+        club_data = bot.api.find_club_in_channel(str(ctx.channel.id), guild_id)
+        if not club_data:
+            await ctx.send("❌ No book club found in this channel.")
+            return
+        try:
+            bot.api.create_member({
+                "name": member.display_name,
+                "discord_id": str(member.id),
+                "clubs": [club_data["id"]]
+            })
+            embed = create_embed(
+                title="✅ Member Added",
+                description=f"**{member.display_name}** has been added to the club.",
+                color_key="success"
+            )
+            await ctx.send(embed=embed)
+        except APIError as e:
+            await ctx.send(f"❌ Failed to add member: {e}")
+
+    @bot.command(name="member_remove", help="Remove a member from the book club")
+    async def member_remove(ctx: commands.Context, member_id: int):
+        """
+        Removes a member by their ID.
+        Usage: !member_remove <member_id>
+        """
+        if not await _check_club_admin(ctx):
+            await ctx.send("❌ You need to be a club admin or owner to use this command.")
+            return
+        confirmed = await _confirm(
+            ctx,
+            f"⚠️ Remove member `{member_id}` from the club? "
+            "Type `y` to confirm or anything else to cancel."
+        )
+        if not confirmed:
+            await ctx.send("Action cancelled.")
+            return
+        try:
+            bot.api.delete_member(member_id)
+            embed = create_embed(
+                title="✅ Member Removed",
+                description=f"Member `{member_id}` has been removed.",
+                color_key="success"
+            )
+            await ctx.send(embed=embed)
+        except APIError as e:
+            await ctx.send(f"❌ Failed to remove member: {e}")
+
+    @bot.command(name="member_role", help="Update a member's role in the club")
+    async def member_role(ctx: commands.Context, member_id: int, role: str):
+        """
+        Sets a member's role to admin or member.
+        Usage: !member_role <member_id> <admin|member>
+        """
+        if not await _check_club_admin(ctx):
+            await ctx.send("❌ You need to be a club admin or owner to use this command.")
+            return
+        if role not in ("admin", "member"):
+            await ctx.send("❌ Role must be `admin` or `member`.")
+            return
+        guild_id = str(ctx.guild.id)
+        club_data = bot.api.find_club_in_channel(str(ctx.channel.id), guild_id)
+        if not club_data:
+            await ctx.send("❌ No book club found in this channel.")
+            return
+        try:
+            bot.api.update_member(member_id, {"club_roles": {club_data["id"]: role}})
+            embed = create_embed(
+                title="✅ Role Updated",
+                description=f"Member `{member_id}` is now **{role}**.",
+                color_key="success"
+            )
+            await ctx.send(embed=embed)
+        except APIError as e:
+            await ctx.send(f"❌ Failed to update role: {e}")
+
+    # ── Session commands (club admin+) ────────────────────────────────────────
+
+    @bot.command(name="session_create", help="Create a new reading session")
+    async def session_create(ctx: commands.Context, book_title: str, *, author: str):
+        """
+        Creates a reading session for the club in this channel.
+        Usage: !session_create "<book title>" <author>
+        """
+        if not await _check_club_admin(ctx):
+            await ctx.send("❌ You need to be a club admin or owner to use this command.")
+            return
+        guild_id = str(ctx.guild.id)
+        club_data = bot.api.find_club_in_channel(str(ctx.channel.id), guild_id)
+        if not club_data:
+            await ctx.send("❌ No book club found in this channel.")
+            return
+        try:
+            bot.api.create_session({
+                "club_id": club_data["id"],
+                "book": {"title": book_title, "author": author}
+            })
+            embed = create_embed(
+                title="✅ Session Created",
+                description=f"Now reading **{book_title}** by {author}.",
+                color_key="success"
+            )
+            await ctx.send(embed=embed)
+        except APIError as e:
+            await ctx.send(f"❌ Failed to create session: {e}")
+
+    @bot.command(name="session_update", help="Update the active reading session")
+    async def session_update(ctx: commands.Context, *, args: str):
+        """
+        Updates the active session. Provide at least one flag.
+        Usage: !session_update [--due-date YYYY-MM-DD] [--book "<title>|<author>"]
+        """
+        if not await _check_club_admin(ctx):
+            await ctx.send("❌ You need to be a club admin or owner to use this command.")
+            return
+        guild_id = str(ctx.guild.id)
+        club_data = bot.api.find_club_in_channel(str(ctx.channel.id), guild_id)
+        if not club_data or not club_data.get("active_session"):
+            await ctx.send("❌ No active session found in this channel.")
+            return
+        session_id = club_data["active_session"]["id"]
+        update = {}
+        due_date_match = re.search(r'--due-date\s+(\S+)', args)
+        book_match = re.search(r'--book\s+"([^|"]+)\|([^"]+)"', args)
+        if due_date_match:
+            update["due_date"] = due_date_match.group(1)
+        if book_match:
+            update["book"] = {
+                "title": book_match.group(1).strip(),
+                "author": book_match.group(2).strip()
+            }
+        if not update:
+            await ctx.send(
+                "❌ Provide at least `--due-date YYYY-MM-DD` or `--book \"<title>|<author>\"`."
+            )
+            return
+        try:
+            bot.api.update_session(session_id, update)
+            embed = create_embed(
+                title="✅ Session Updated",
+                description="Session details updated successfully.",
+                color_key="success"
+            )
+            await ctx.send(embed=embed)
+        except APIError as e:
+            await ctx.send(f"❌ Failed to update session: {e}")
+
+    @bot.command(name="session_delete", help="Delete the active reading session")
+    async def session_delete(ctx: commands.Context):
+        """
+        Deletes the active session for the club in this channel.
+        Usage: !session_delete
+        """
+        if not await _check_club_admin(ctx):
+            await ctx.send("❌ You need to be a club admin or owner to use this command.")
+            return
+        guild_id = str(ctx.guild.id)
+        club_data = bot.api.find_club_in_channel(str(ctx.channel.id), guild_id)
+        if not club_data or not club_data.get("active_session"):
+            await ctx.send("❌ No active session found in this channel.")
+            return
+        session_id = club_data["active_session"]["id"]
+        confirmed = await _confirm(
+            ctx,
+            "⚠️ This will permanently delete the active reading session. "
+            "Type `y` to confirm or anything else to cancel."
+        )
+        if not confirmed:
+            await ctx.send("Action cancelled.")
+            return
+        try:
+            bot.api.delete_session(session_id)
+            embed = create_embed(
+                title="✅ Session Deleted",
+                description="The active reading session has been deleted.",
+                color_key="success"
+            )
+            await ctx.send(embed=embed)
+        except APIError as e:
+            await ctx.send(f"❌ Failed to delete session: {e}")

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -179,27 +179,24 @@ def setup_admin_commands(bot):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         try:
+            # Resolve or create the caller's member record so we can pass
+            # them as the first member in the club payload — the backend
+            # promotes index-0 to owner automatically.
+            existing = bot.api.get_member_by_discord_id(str(ctx.author.id))
+            if existing:
+                caller = {"id": existing["id"], "name": existing["name"]}
+            else:
+                created = bot.api.create_member({
+                    "name": ctx.author.display_name,
+                    "discord_id": str(ctx.author.id),
+                })
+                member_data = created.get("member", created)
+                caller = {"id": member_data["id"], "name": member_data["name"]}
+
             bot.api.create_club(
-                {"name": name, "discord_channel": channel_id},
+                {"name": name, "discord_channel": channel_id, "members": [caller]},
                 str(ctx.guild.id)
             )
-            # Auto-assign caller as club owner
-            club_data = bot.api.find_club_in_channel(channel_id, str(ctx.guild.id))
-            if club_data:
-                existing = bot.api.get_member_by_discord_id(str(ctx.author.id))
-                if existing:
-                    current_club_ids = [c["id"] for c in existing.get("clubs", [])]
-                    bot.api.update_member(existing["id"], {
-                        "clubs": current_club_ids + [club_data["id"]],
-                        "club_roles": {club_data["id"]: "owner"}
-                    })
-                else:
-                    bot.api.create_member({
-                        "name": ctx.author.display_name,
-                        "discord_id": str(ctx.author.id),
-                        "clubs": [club_data["id"]],
-                        "club_roles": {club_data["id"]: "owner"}
-                    })
             embed = create_embed(
                 title="✅ Club Created",
                 description=f"Book club **{name}** created in <#{channel_id}>. You are the owner.",

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -267,11 +267,19 @@ def setup_admin_commands(bot):
             await ctx.send("❌ No book club found in this channel.")
             return
         try:
-            bot.api.create_member({
-                "name": member.display_name,
-                "discord_id": str(member.id),
-                "clubs": [club_data["id"]]
-            })
+            existing = bot.api.get_member_by_discord_id(str(member.id))
+            if existing:
+                current_club_ids = [c["id"] for c in existing.get("clubs", [])]
+                if club_data["id"] in current_club_ids:
+                    await ctx.send(f"**{member.display_name}** is already a member of this club.")
+                    return
+                bot.api.update_member(existing["id"], {"clubs": current_club_ids + [club_data["id"]]})
+            else:
+                bot.api.create_member({
+                    "name": member.display_name,
+                    "discord_id": str(member.id),
+                    "clubs": [club_data["id"]]
+                })
             embed = create_embed(
                 title="✅ Member Added",
                 description=f"**{member.display_name}** has been added to the club.",

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -22,19 +22,23 @@ def setup_admin_commands(bot):
         """Returns True if the command author is the Discord guild owner."""
         return ctx.author == ctx.guild.owner
 
-    async def _can_manage_clubs(ctx):
-        """Returns True if user is guild owner OR club admin in the current channel's club."""
+    async def _can_manage_clubs(ctx, channel_id: str = None):
+        """Returns True if user is guild owner OR club admin in the target channel's club."""
         if _check_guild_owner(ctx):
             return True
-        guild_id = str(ctx.guild.id)
-        channel_id = str(ctx.channel.id)
-        club_data = bot.api.find_club_in_channel(channel_id, guild_id)
+        target = channel_id or str(ctx.channel.id)
+        club_data = bot.api.find_club_in_channel(target, str(ctx.guild.id))
         if not club_data:
             return False
         for member in club_data.get("members", []):
             if str(member.get("discord_id")) == str(ctx.author.id):
                 return member.get("role") in ("admin", "owner")
         return False
+
+    def _resolve_channel_id(ctx, args: str = ""):
+        """Extracts --channel <id> from args, falling back to the current channel."""
+        match = re.search(r'--channel\s+(\d+)', args)
+        return match.group(1) if match else str(ctx.channel.id)
 
     async def _confirm(ctx, prompt):
         """Sends a y/n prompt; returns True only if the user replies 'y' within 30 seconds."""
@@ -159,52 +163,78 @@ def setup_admin_commands(bot):
 
     # ── Club commands (club admin+) ───────────────────────────────────────────
 
-    @bot.command(name="club_create", help="Create a new book club in this channel")
-    async def club_create(ctx: commands.Context, *, name: str):
+    @bot.command(name="club_create", help="Create a new book club in a channel")
+    async def club_create(ctx: commands.Context, *, args: str):
         """
-        Creates a new book club linked to the current channel.
-        Usage: !club_create <name>
+        Creates a new book club. Caller is automatically assigned as owner.
+        Usage: !club_create <name> [--channel <channel_id>]
         """
-        if not await _can_manage_clubs(ctx):
+        channel_id = _resolve_channel_id(ctx, args)
+        name = re.sub(r'\s*--channel\s+\d+', '', args).strip()
+
+        if not name:
+            await ctx.send("❌ Provide a club name: `!club_create <name> [--channel <id>]`")
+            return
+        if not await _can_manage_clubs(ctx, channel_id):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         try:
             bot.api.create_club(
-                {"name": name, "discord_channel": str(ctx.channel.id)},
+                {"name": name, "discord_channel": channel_id},
                 str(ctx.guild.id)
             )
+            # Auto-assign caller as club owner
+            club_data = bot.api.find_club_in_channel(channel_id, str(ctx.guild.id))
+            if club_data:
+                existing = bot.api.get_member_by_discord_id(str(ctx.author.id))
+                if existing:
+                    current_club_ids = [c["id"] for c in existing.get("clubs", [])]
+                    bot.api.update_member(existing["id"], {
+                        "clubs": current_club_ids + [club_data["id"]],
+                        "club_roles": {club_data["id"]: "owner"}
+                    })
+                else:
+                    bot.api.create_member({
+                        "name": ctx.author.display_name,
+                        "discord_id": str(ctx.author.id),
+                        "clubs": [club_data["id"]],
+                        "club_roles": {club_data["id"]: "owner"}
+                    })
             embed = create_embed(
                 title="✅ Club Created",
-                description=f"Book club **{name}** created in this channel.",
+                description=f"Book club **{name}** created in <#{channel_id}>. You are the owner.",
                 color_key="success"
             )
             await ctx.send(embed=embed)
         except APIError as e:
             await ctx.send(f"❌ Failed to create club: {e}")
 
-    @bot.command(name="club_update", help="Update the club name or channel")
+    @bot.command(name="club_update", help="Update the club name or discord channel")
     async def club_update(ctx: commands.Context, *, args: str):
         """
-        Updates club details. Provide at least one flag.
-        Usage: !club_update [--name <name>] [--channel <channel_id>]
+        Updates club details. Use --channel to target a club from another channel.
+        Usage: !club_update [--name <name>] [--new-channel <channel_id>] [--channel <channel_id>]
         """
-        if not await _can_manage_clubs(ctx):
+        channel_id = _resolve_channel_id(ctx, args)
+        if not await _can_manage_clubs(ctx, channel_id):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         guild_id = str(ctx.guild.id)
-        club_data = bot.api.find_club_in_channel(str(ctx.channel.id), guild_id)
+        club_data = bot.api.find_club_in_channel(channel_id, guild_id)
         if not club_data:
-            await ctx.send("❌ No book club found in this channel.")
+            await ctx.send("❌ No book club found in that channel.")
             return
         update = {}
         name_match = re.search(r'--name\s+(.+?)(?:\s+--|$)', args)
-        channel_match = re.search(r'--channel\s+(\S+)', args)
+        new_channel_match = re.search(r'--new-channel\s+(\d+)', args)
         if name_match:
             update["name"] = name_match.group(1).strip()
-        if channel_match:
-            update["discord_channel"] = channel_match.group(1).strip()
+        if new_channel_match:
+            update["discord_channel"] = new_channel_match.group(1).strip()
         if not update:
-            await ctx.send("❌ Provide at least `--name <name>` or `--channel <channel_id>`.")
+            await ctx.send(
+                "❌ Provide at least `--name <name>` or `--new-channel <channel_id>`."
+            )
             return
         try:
             bot.api.update_club(club_data["id"], update, guild_id)
@@ -217,19 +247,20 @@ def setup_admin_commands(bot):
         except APIError as e:
             await ctx.send(f"❌ Failed to update club: {e}")
 
-    @bot.command(name="club_delete", help="Delete the book club in this channel")
-    async def club_delete(ctx: commands.Context):
+    @bot.command(name="club_delete", help="Delete the book club in a channel")
+    async def club_delete(ctx: commands.Context, *, args: str = ""):
         """
-        Deletes the book club linked to the current channel.
-        Usage: !club_delete
+        Deletes a book club and all its data.
+        Usage: !club_delete [--channel <channel_id>]
         """
-        if not await _can_manage_clubs(ctx):
+        channel_id = _resolve_channel_id(ctx, args)
+        if not await _can_manage_clubs(ctx, channel_id):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         guild_id = str(ctx.guild.id)
-        club_data = bot.api.find_club_in_channel(str(ctx.channel.id), guild_id)
+        club_data = bot.api.find_club_in_channel(channel_id, guild_id)
         if not club_data:
-            await ctx.send("❌ No book club found in this channel.")
+            await ctx.send("❌ No book club found in that channel.")
             return
         confirmed = await _confirm(
             ctx,
@@ -252,19 +283,19 @@ def setup_admin_commands(bot):
 
     # ── Member commands (club admin+) ─────────────────────────────────────────
 
-    @bot.command(name="member_add", help="Add a Discord user to the book club")
-    async def member_add(ctx: commands.Context, member: discord.Member):
+    @bot.command(name="member_add", help="Add a Discord user to a book club")
+    async def member_add(ctx: commands.Context, member: discord.Member, *, args: str = ""):
         """
-        Adds a mentioned Discord user to the book club in this channel.
-        Usage: !member_add @User
+        Adds a mentioned Discord user to a club. Creates member record if needed.
+        Usage: !member_add @User [--channel <channel_id>]
         """
-        if not await _can_manage_clubs(ctx):
+        channel_id = _resolve_channel_id(ctx, args)
+        if not await _can_manage_clubs(ctx, channel_id):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
-        guild_id = str(ctx.guild.id)
-        club_data = bot.api.find_club_in_channel(str(ctx.channel.id), guild_id)
+        club_data = bot.api.find_club_in_channel(channel_id, str(ctx.guild.id))
         if not club_data:
-            await ctx.send("❌ No book club found in this channel.")
+            await ctx.send("❌ No book club found in that channel.")
             return
         try:
             existing = bot.api.get_member_by_discord_id(str(member.id))
@@ -289,13 +320,14 @@ def setup_admin_commands(bot):
         except APIError as e:
             await ctx.send(f"❌ Failed to add member: {e}")
 
-    @bot.command(name="member_remove", help="Remove a member from the book club")
-    async def member_remove(ctx: commands.Context, member_id: int):
+    @bot.command(name="member_remove", help="Remove a member from a book club")
+    async def member_remove(ctx: commands.Context, member_id: int, *, args: str = ""):
         """
         Removes a member by their ID.
-        Usage: !member_remove <member_id>
+        Usage: !member_remove <member_id> [--channel <channel_id>]
         """
-        if not await _can_manage_clubs(ctx):
+        channel_id = _resolve_channel_id(ctx, args)
+        if not await _can_manage_clubs(ctx, channel_id):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         confirmed = await _confirm(
@@ -317,22 +349,23 @@ def setup_admin_commands(bot):
         except APIError as e:
             await ctx.send(f"❌ Failed to remove member: {e}")
 
-    @bot.command(name="member_role", help="Update a member's role in the club")
-    async def member_role(ctx: commands.Context, member_id: int, role: str):
+    @bot.command(name="member_role", help="Update a member's role in a club")
+    async def member_role(ctx: commands.Context, member_id: int, role: str, *, args: str = ""):
         """
         Sets a member's role to admin or member.
-        Usage: !member_role <member_id> <admin|member>
+        Usage: !member_role <member_id> <admin|member> [--channel <channel_id>]
         """
-        if not await _can_manage_clubs(ctx):
+        channel_id = _resolve_channel_id(ctx, args)
+        if not await _can_manage_clubs(ctx, channel_id):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         if role not in ("admin", "member"):
             await ctx.send("❌ Role must be `admin` or `member`.")
             return
         guild_id = str(ctx.guild.id)
-        club_data = bot.api.find_club_in_channel(str(ctx.channel.id), guild_id)
+        club_data = bot.api.find_club_in_channel(channel_id, guild_id)
         if not club_data:
-            await ctx.send("❌ No book club found in this channel.")
+            await ctx.send("❌ No book club found in that channel.")
             return
         try:
             bot.api.update_member(member_id, {"club_roles": {club_data["id"]: role}})
@@ -350,16 +383,18 @@ def setup_admin_commands(bot):
     @bot.command(name="session_create", help="Create a new reading session")
     async def session_create(ctx: commands.Context, book_title: str, *, author: str):
         """
-        Creates a reading session for the club in this channel.
-        Usage: !session_create "<book title>" <author>
+        Creates a reading session for a club.
+        Usage: !session_create "<book title>" <author> [--channel <channel_id>]
         """
-        if not await _can_manage_clubs(ctx):
+        channel_id = _resolve_channel_id(ctx, author)
+        author = re.sub(r'\s*--channel\s+\d+', '', author).strip()
+
+        if not await _can_manage_clubs(ctx, channel_id):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
-        guild_id = str(ctx.guild.id)
-        club_data = bot.api.find_club_in_channel(str(ctx.channel.id), guild_id)
+        club_data = bot.api.find_club_in_channel(channel_id, str(ctx.guild.id))
         if not club_data:
-            await ctx.send("❌ No book club found in this channel.")
+            await ctx.send("❌ No book club found in that channel.")
             return
         try:
             bot.api.create_session({
@@ -379,15 +414,16 @@ def setup_admin_commands(bot):
     async def session_update(ctx: commands.Context, *, args: str):
         """
         Updates the active session. Provide at least one flag.
-        Usage: !session_update [--due-date YYYY-MM-DD] [--book "<title>|<author>"]
+        Usage: !session_update [--due-date YYYY-MM-DD] [--book "<title>|<author>"] [--channel <channel_id>]
         """
-        if not await _can_manage_clubs(ctx):
+        channel_id = _resolve_channel_id(ctx, args)
+        if not await _can_manage_clubs(ctx, channel_id):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         guild_id = str(ctx.guild.id)
-        club_data = bot.api.find_club_in_channel(str(ctx.channel.id), guild_id)
+        club_data = bot.api.find_club_in_channel(channel_id, guild_id)
         if not club_data or not club_data.get("active_session"):
-            await ctx.send("❌ No active session found in this channel.")
+            await ctx.send("❌ No active session found in that channel.")
             return
         session_id = club_data["active_session"]["id"]
         update = {}
@@ -417,18 +453,19 @@ def setup_admin_commands(bot):
             await ctx.send(f"❌ Failed to update session: {e}")
 
     @bot.command(name="session_delete", help="Delete the active reading session")
-    async def session_delete(ctx: commands.Context):
+    async def session_delete(ctx: commands.Context, *, args: str = ""):
         """
-        Deletes the active session for the club in this channel.
-        Usage: !session_delete
+        Deletes the active session for a club.
+        Usage: !session_delete [--channel <channel_id>]
         """
-        if not await _can_manage_clubs(ctx):
+        channel_id = _resolve_channel_id(ctx, args)
+        if not await _can_manage_clubs(ctx, channel_id):
             await ctx.send("❌ You need to be a club admin or owner to use this command.")
             return
         guild_id = str(ctx.guild.id)
-        club_data = bot.api.find_club_in_channel(str(ctx.channel.id), guild_id)
+        club_data = bot.api.find_club_in_channel(channel_id, guild_id)
         if not club_data or not club_data.get("active_session"):
-            await ctx.send("❌ No active session found in this channel.")
+            await ctx.send("❌ No active session found in that channel.")
             return
         session_id = club_data["active_session"]["id"]
         confirmed = await _confirm(

--- a/docs/ADMIN_COMMANDS.md
+++ b/docs/ADMIN_COMMANDS.md
@@ -5,13 +5,30 @@ All admin commands are **prefix commands** (use `!` prefix, not `/`).
 ## Permission Model
 
 - **Server commands**: Guild owner only
-- **Club/Member/Session commands**: Guild owner OR club admin/owner
+- **Club/Member/Session commands**: Guild owner OR club admin/owner in the target club
 
-Guild owners have unrestricted access to all commands in their server. This allows bootstrapping: register server → create first club → add members → promote an admin.
+Guild owners have unrestricted access to all commands in their server. This allows bootstrapping:
+register server → create first club → add members → promote an admin.
+
+## Using an Admin Channel
+
+All club/member/session commands accept an optional `--channel <id>` flag so they can be
+issued from a dedicated `#admin` channel without needing to navigate to the club channel.
+
+```
+# From #admin channel, targeting #book-club (id: 123456789)
+!member_add @alice --channel 123456789
+!session_create "Dune" Frank Herbert --channel 123456789
+!club_delete --channel 123456789
+```
+
+Omitting `--channel` targets the current channel as usual.
+
+---
 
 ## Server Commands
 
-Commands for managing server registration and settings.
+These are server-wide operations and do **not** support `--channel`.
 
 ### `!server_register`
 
@@ -20,13 +37,6 @@ Registers the Discord server with the bot.
 **Permission**: Guild owner only  
 **Usage**: `!server_register`
 
-**Example**:
-```
-!server_register
-```
-
-**Response**: Confirms server registration
-
 ### `!server_update <name>`
 
 Updates the server's registered name.
@@ -34,231 +44,179 @@ Updates the server's registered name.
 **Permission**: Guild owner only  
 **Usage**: `!server_update <new_name>`
 
-**Example**:
-```
-!server_update "My Book Club Server"
-```
-
-**Response**: Confirms name update
+**Example**: `!server_update "My Book Club Server"`
 
 ### `!server_delete`
 
 Deletes the server registration and ALL associated data (clubs, members, sessions).
 
 **Permission**: Guild owner only  
-**Usage**: `!server_delete`
+**Usage**: `!server_delete`  
+**Confirmation**: Requires `y`
 
-**Confirmation**: Requires typing `y` to confirm; any other response cancels
-
-**Example**:
-```
-!server_delete
-⚠️ This will delete **all server data** including clubs, members, and sessions...
-> y
-✅ Server registration and all associated data have been removed.
-```
+---
 
 ## Club Commands
 
-Commands for managing book clubs within the server.
+### `!club_create <name> [--channel <channel_id>]`
 
-### `!club_create <name>`
+Creates a new book club. The caller is **automatically assigned as club owner**.
 
-Creates a new book club in the current channel.
+**Permission**: Guild owner OR club admin in the target channel  
+**Usage**: `!club_create <name> [--channel <channel_id>]`
 
-**Permission**: Guild owner OR club admin in this channel  
-**Usage**: `!club_create <club_name>`
-
-**Example**:
+**Examples**:
 ```
 !club_create "Classic Literature"
+!club_create "Sci-Fi Club" --channel 123456789
 ```
 
-**Response**: Confirms club creation in the channel
+### `!club_update [--name <name>] [--new-channel <channel_id>] [--channel <channel_id>]`
 
-### `!club_update [--name <name>] [--channel <channel_id>]`
+Updates club details. Use `--new-channel` to move the club to a different Discord channel.
+Use `--channel` to target a specific club from another channel (e.g. `#admin`).
 
-Updates club details. At least one flag required.
-
-**Permission**: Guild owner OR club admin in this channel  
-**Usage**: `!club_update --name "New Name"` or `!club_update --channel 123456789` or both
+**Permission**: Guild owner OR club admin in the target channel  
+**At least one of** `--name` or `--new-channel` required
 
 **Examples**:
 ```
 !club_update --name "Sci-Fi Readers"
-!club_update --channel 987654321
-!club_update --name "Updated Club" --channel 987654321
+!club_update --new-channel 987654321
+!club_update --name "Updated" --new-channel 987654321 --channel 123456789
 ```
 
-**Response**: Confirms club update
+### `!club_delete [--channel <channel_id>]`
 
-### `!club_delete`
+Deletes the book club and all its data.
 
-Deletes the book club in the current channel and all associated sessions.
+**Permission**: Guild owner OR club admin in the target channel  
+**Usage**: `!club_delete [--channel <channel_id>]`  
+**Confirmation**: Requires `y`
 
-**Permission**: Guild owner OR club admin in this channel  
-**Usage**: `!club_delete`
+**Example**: `!club_delete --channel 123456789`
 
-**Confirmation**: Requires typing `y` to confirm
-
-**Example**:
-```
-!club_delete
-⚠️ This will delete **Test Club** and all its data...
-> y
-✅ **Test Club** has been deleted.
-```
+---
 
 ## Member Commands
 
-Commands for managing club members.
+### `!member_add @User [--channel <channel_id>]`
 
-### `!member_add @User`
+Adds a Discord user to a club. If the user already has a member record (from another club),
+they are linked to this club without creating a duplicate.
 
-Adds a Discord user to the current channel's book club.
+**Permission**: Guild owner OR club admin in the target channel  
+**Usage**: `!member_add @Username [--channel <channel_id>]`
 
-**Permission**: Guild owner OR club admin in this channel  
-**Usage**: `!member_add @Username`
-
-**Example**:
+**Examples**:
 ```
 !member_add @alice
+!member_add @alice --channel 123456789
 ```
 
-**Response**: Confirms member addition and displays their name
+### `!member_remove <member_id> [--channel <channel_id>]`
 
-### `!member_remove <member_id>`
+Removes a member by their ID.
 
-Removes a member from the club.
+**Permission**: Guild owner OR club admin in the target channel  
+**Usage**: `!member_remove <member_id> [--channel <channel_id>]`  
+**Confirmation**: Requires `y`
 
-**Permission**: Guild owner OR club admin in this channel  
-**Usage**: `!member_remove <member_id>`
+**Example**: `!member_remove 42 --channel 123456789`
 
-**Confirmation**: Requires typing `y` to confirm
-
-**Example**:
-```
-!member_remove 42
-⚠️ Remove member `42` from the club...
-> y
-✅ Member `42` has been removed.
-```
-
-### `!member_role <member_id> <role>`
+### `!member_role <member_id> <role> [--channel <channel_id>]`
 
 Updates a member's role in the club.
 
-**Permission**: Guild owner OR club admin in this channel  
-**Usage**: `!member_role <member_id> <admin|member>`
+**Permission**: Guild owner OR club admin in the target channel  
+**Usage**: `!member_role <member_id> <admin|member> [--channel <channel_id>]`
 
 **Roles**:
-- `admin` - Can manage club/members/sessions
-- `member` - Can view club content only
+- `admin` — Can manage club/members/sessions
+- `member` — Standard membership, read-only access to club commands
 
 **Examples**:
 ```
 !member_role 42 admin
-!member_role 42 member
+!member_role 42 member --channel 123456789
 ```
 
-**Response**: Confirms role update
-
-**Error**: Invalid role (must be `admin` or `member`)
+---
 
 ## Session Commands
 
-Commands for managing reading sessions.
+### `!session_create "<book_title>" <author> [--channel <channel_id>]`
 
-### `!session_create <book_title> <author>`
+Creates a new reading session for a club.
 
-Creates a new reading session for the club.
+**Permission**: Guild owner OR club admin in the target channel  
+**Usage**: `!session_create "<title>" <author> [--channel <channel_id>]`
 
-**Permission**: Guild owner OR club admin in this channel  
-**Usage**: `!session_create "<title>" <author>`
-
-**Example**:
+**Examples**:
 ```
 !session_create "The Great Gatsby" F. Scott Fitzgerald
+!session_create "Dune" Frank Herbert --channel 123456789
 ```
 
-**Response**: Confirms session creation with book title
+### `!session_update [--due-date YYYY-MM-DD] [--book "<title>|<author>"] [--channel <channel_id>]`
 
-### `!session_update [--due-date YYYY-MM-DD] [--book "<title>|<author>"]`
+Updates the active session. At least one of `--due-date` or `--book` required.
 
-Updates the active session. At least one flag required.
-
-**Permission**: Guild owner OR club admin in this channel  
-**Usage**: `!session_update --due-date YYYY-MM-DD` or `!session_update --book "<title>|<author>"` or both
+**Permission**: Guild owner OR club admin in the target channel  
+**Note**: Book format uses a pipe separator: `"<title>|<author>"`
 
 **Examples**:
 ```
 !session_update --due-date 2026-06-15
 !session_update --book "Dune|Frank Herbert"
-!session_update --due-date 2026-06-15 --book "Dune|Frank Herbert"
+!session_update --due-date 2026-06-15 --book "Dune|Frank Herbert" --channel 123456789
 ```
 
-**Response**: Confirms session update
+### `!session_delete [--channel <channel_id>]`
 
-**Note**: Book format is `"<title>|<author>"` with pipe separator
+Deletes the active reading session.
 
-### `!session_delete`
+**Permission**: Guild owner OR club admin in the target channel  
+**Usage**: `!session_delete [--channel <channel_id>]`  
+**Confirmation**: Requires `y`
 
-Deletes the active reading session for the club.
+**Example**: `!session_delete --channel 123456789`
 
-**Permission**: Guild owner OR club admin in this channel  
-**Usage**: `!session_delete`
+---
 
-**Confirmation**: Requires typing `y` to confirm
-
-**Example**:
-```
-!session_delete
-⚠️ This will permanently delete the active reading session...
-> y
-✅ The active reading session has been deleted.
-```
-
-## Error Messages
-
-### Common Errors
+## Error Reference
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| `❌ Only the server owner can use this command` | Non-owner trying server command | Ask guild owner to run |
-| `❌ You need to be a club admin or owner to use this command` | Non-admin/owner trying club op | Ask club admin or guild owner to run |
-| `❌ No book club found in this channel` | Channel has no linked club | Create club first with `!club_create` |
-| `❌ No active session found in this channel` | No reading session in progress | Create session with `!session_create` |
-| `❌ Role must be 'admin' or 'member'` | Invalid role in `!member_role` | Use `admin` or `member` only |
-| `⏰ Confirmation timed out` | Didn't confirm `y/n` within 30 seconds | Re-run the command |
+| `❌ Only the server owner can use this command` | Non-owner running a server command | Ask the guild owner |
+| `❌ You need to be a club admin or owner` | Insufficient permissions | Ask a club admin or the guild owner |
+| `❌ No book club found in that channel` | No club linked to the target channel | Create one with `!club_create` |
+| `❌ No active session found in that channel` | No reading session in progress | Create one with `!session_create` |
+| `❌ Role must be 'admin' or 'member'` | Invalid role in `!member_role` | Use `admin` or `member` |
+| `⏰ Confirmation timed out` | No response within 30 seconds | Re-run the command |
+
+---
 
 ## Bootstrap Workflow
 
-Fresh server setup:
+Fresh server setup from an `#admin` channel (channel ID: `123456`):
 
 ```
-1. Guild Owner: !server_register
+1. !server_register
    ✅ Server registered
 
-2. Guild Owner: !club_create "My Book Club"
-   ✅ Club created in #channel
+2. !club_create "My Book Club" --channel 123456
+   ✅ Club created — caller assigned as owner
 
-3. Guild Owner: !member_add @alice
+3. !member_add @alice --channel 123456
    ✅ Alice added
 
-4. Guild Owner: !member_role <alice_id> admin
+4. !member_role <alice_id> admin --channel 123456
    ✅ Alice is now admin
 
-5. Alice (club admin): !session_create "Dune" Frank Herbert
+5. !session_create "Dune" Frank Herbert --channel 123456
    ✅ Session created
 
-6. Alice: !session_update --due-date 2026-06-15
+6. !session_update --due-date 2026-06-15 --channel 123456
    ✅ Due date set
 ```
-
-## Notes
-
-- All destructive commands (`_delete`) require `y/n` confirmation
-- Confirmation timeout is **30 seconds**
-- Guild owner can bypass club admin requirement for all club/member/session operations
-- Each club is tied to a Discord channel
-- Members are identified by Discord ID, not mention (for robustness)

--- a/docs/ADMIN_COMMANDS.md
+++ b/docs/ADMIN_COMMANDS.md
@@ -1,0 +1,264 @@
+# Admin Commands Guide
+
+All admin commands are **prefix commands** (use `!` prefix, not `/`).
+
+## Permission Model
+
+- **Server commands**: Guild owner only
+- **Club/Member/Session commands**: Guild owner OR club admin/owner
+
+Guild owners have unrestricted access to all commands in their server. This allows bootstrapping: register server → create first club → add members → promote an admin.
+
+## Server Commands
+
+Commands for managing server registration and settings.
+
+### `!server_register`
+
+Registers the Discord server with the bot.
+
+**Permission**: Guild owner only  
+**Usage**: `!server_register`
+
+**Example**:
+```
+!server_register
+```
+
+**Response**: Confirms server registration
+
+### `!server_update <name>`
+
+Updates the server's registered name.
+
+**Permission**: Guild owner only  
+**Usage**: `!server_update <new_name>`
+
+**Example**:
+```
+!server_update "My Book Club Server"
+```
+
+**Response**: Confirms name update
+
+### `!server_delete`
+
+Deletes the server registration and ALL associated data (clubs, members, sessions).
+
+**Permission**: Guild owner only  
+**Usage**: `!server_delete`
+
+**Confirmation**: Requires typing `y` to confirm; any other response cancels
+
+**Example**:
+```
+!server_delete
+⚠️ This will delete **all server data** including clubs, members, and sessions...
+> y
+✅ Server registration and all associated data have been removed.
+```
+
+## Club Commands
+
+Commands for managing book clubs within the server.
+
+### `!club_create <name>`
+
+Creates a new book club in the current channel.
+
+**Permission**: Guild owner OR club admin in this channel  
+**Usage**: `!club_create <club_name>`
+
+**Example**:
+```
+!club_create "Classic Literature"
+```
+
+**Response**: Confirms club creation in the channel
+
+### `!club_update [--name <name>] [--channel <channel_id>]`
+
+Updates club details. At least one flag required.
+
+**Permission**: Guild owner OR club admin in this channel  
+**Usage**: `!club_update --name "New Name"` or `!club_update --channel 123456789` or both
+
+**Examples**:
+```
+!club_update --name "Sci-Fi Readers"
+!club_update --channel 987654321
+!club_update --name "Updated Club" --channel 987654321
+```
+
+**Response**: Confirms club update
+
+### `!club_delete`
+
+Deletes the book club in the current channel and all associated sessions.
+
+**Permission**: Guild owner OR club admin in this channel  
+**Usage**: `!club_delete`
+
+**Confirmation**: Requires typing `y` to confirm
+
+**Example**:
+```
+!club_delete
+⚠️ This will delete **Test Club** and all its data...
+> y
+✅ **Test Club** has been deleted.
+```
+
+## Member Commands
+
+Commands for managing club members.
+
+### `!member_add @User`
+
+Adds a Discord user to the current channel's book club.
+
+**Permission**: Guild owner OR club admin in this channel  
+**Usage**: `!member_add @Username`
+
+**Example**:
+```
+!member_add @alice
+```
+
+**Response**: Confirms member addition and displays their name
+
+### `!member_remove <member_id>`
+
+Removes a member from the club.
+
+**Permission**: Guild owner OR club admin in this channel  
+**Usage**: `!member_remove <member_id>`
+
+**Confirmation**: Requires typing `y` to confirm
+
+**Example**:
+```
+!member_remove 42
+⚠️ Remove member `42` from the club...
+> y
+✅ Member `42` has been removed.
+```
+
+### `!member_role <member_id> <role>`
+
+Updates a member's role in the club.
+
+**Permission**: Guild owner OR club admin in this channel  
+**Usage**: `!member_role <member_id> <admin|member>`
+
+**Roles**:
+- `admin` - Can manage club/members/sessions
+- `member` - Can view club content only
+
+**Examples**:
+```
+!member_role 42 admin
+!member_role 42 member
+```
+
+**Response**: Confirms role update
+
+**Error**: Invalid role (must be `admin` or `member`)
+
+## Session Commands
+
+Commands for managing reading sessions.
+
+### `!session_create <book_title> <author>`
+
+Creates a new reading session for the club.
+
+**Permission**: Guild owner OR club admin in this channel  
+**Usage**: `!session_create "<title>" <author>`
+
+**Example**:
+```
+!session_create "The Great Gatsby" F. Scott Fitzgerald
+```
+
+**Response**: Confirms session creation with book title
+
+### `!session_update [--due-date YYYY-MM-DD] [--book "<title>|<author>"]`
+
+Updates the active session. At least one flag required.
+
+**Permission**: Guild owner OR club admin in this channel  
+**Usage**: `!session_update --due-date YYYY-MM-DD` or `!session_update --book "<title>|<author>"` or both
+
+**Examples**:
+```
+!session_update --due-date 2026-06-15
+!session_update --book "Dune|Frank Herbert"
+!session_update --due-date 2026-06-15 --book "Dune|Frank Herbert"
+```
+
+**Response**: Confirms session update
+
+**Note**: Book format is `"<title>|<author>"` with pipe separator
+
+### `!session_delete`
+
+Deletes the active reading session for the club.
+
+**Permission**: Guild owner OR club admin in this channel  
+**Usage**: `!session_delete`
+
+**Confirmation**: Requires typing `y` to confirm
+
+**Example**:
+```
+!session_delete
+⚠️ This will permanently delete the active reading session...
+> y
+✅ The active reading session has been deleted.
+```
+
+## Error Messages
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `❌ Only the server owner can use this command` | Non-owner trying server command | Ask guild owner to run |
+| `❌ You need to be a club admin or owner to use this command` | Non-admin/owner trying club op | Ask club admin or guild owner to run |
+| `❌ No book club found in this channel` | Channel has no linked club | Create club first with `!club_create` |
+| `❌ No active session found in this channel` | No reading session in progress | Create session with `!session_create` |
+| `❌ Role must be 'admin' or 'member'` | Invalid role in `!member_role` | Use `admin` or `member` only |
+| `⏰ Confirmation timed out` | Didn't confirm `y/n` within 30 seconds | Re-run the command |
+
+## Bootstrap Workflow
+
+Fresh server setup:
+
+```
+1. Guild Owner: !server_register
+   ✅ Server registered
+
+2. Guild Owner: !club_create "My Book Club"
+   ✅ Club created in #channel
+
+3. Guild Owner: !member_add @alice
+   ✅ Alice added
+
+4. Guild Owner: !member_role <alice_id> admin
+   ✅ Alice is now admin
+
+5. Alice (club admin): !session_create "Dune" Frank Herbert
+   ✅ Session created
+
+6. Alice: !session_update --due-date 2026-06-15
+   ✅ Due date set
+```
+
+## Notes
+
+- All destructive commands (`_delete`) require `y/n` confirmation
+- Confirmation timeout is **30 seconds**
+- Guild owner can bypass club admin requirement for all club/member/session operations
+- Each club is tied to a Discord channel
+- Members are identified by Discord ID, not mention (for robustness)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -404,7 +404,7 @@ Coverage reports are automatically uploaded to [codecov.io](https://codecov.io) 
 
 **Coverage badge:**
 ```markdown
-[![codecov](https://codecov.io/gh/ivangarzab/quill-bot/branch/main/graph/badge.svg)](https://codecov.io/gh/ivangarzab/quill-bot)
+[![codecov](https://codecov.io/gh/kluvs-api/quill-bot/branch/main/graph/badge.svg)](https://codecov.io/gh/kluvs-api/quill-bot)
 ```
 
 ## Testing Strategy

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -49,6 +49,22 @@ def _club_with_admin(author_id, club_id="club-1", session_id="sess-1"):
     }
 
 
+class TestConfirmFlow(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.bot, self.commands = _make_bot()
+
+    async def test_confirm_timeout(self):
+        ctx = _make_ctx()
+        self.bot.wait_for.side_effect = TimeoutError()
+        club = _club_with_admin("111")
+        self.bot.api.find_club_in_channel.return_value = club
+        await self.commands["club_delete"]["func"](ctx)
+        # Should not call API when timeout occurs
+        self.bot.api.delete_club.assert_not_called()
+        # Should have sent 3 messages: prompt, timeout, and cancellation
+        self.assertEqual(ctx.send.call_count, 3)
+
+
 class TestVersionCommand(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.bot, self.commands = _make_bot()
@@ -143,6 +159,21 @@ class TestServerCommands(unittest.IsolatedAsyncioTestCase):
         await self.commands["server_delete"]["func"](ctx)
         self.bot.api.delete_server.assert_not_called()
 
+    async def test_server_delete_api_error(self):
+        ctx = _make_ctx()
+        confirm_msg = MagicMock()
+        confirm_msg.content = "y"
+        self.bot.wait_for.return_value = confirm_msg
+        self.bot.api.delete_server.side_effect = APIError("failed to delete")
+        await self.commands["server_delete"]["func"](ctx)
+        self.assertIn("❌", ctx.send.call_args_list[-1].args[0])
+
+    async def test_server_update_api_error(self):
+        ctx = _make_ctx()
+        self.bot.api.update_server.side_effect = APIError("update failed")
+        await self.commands["server_update"]["func"](ctx, name="New Name")
+        self.assertIn("❌", ctx.send.call_args.args[0])
+
 
 class TestClubAdminCheck(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
@@ -173,6 +204,27 @@ class TestClubAdminCheck(unittest.IsolatedAsyncioTestCase):
             "members": [{"discord_id": "111", "role": "member"}],
         }
         await self.commands["club_create"]["func"](ctx, name="New Club")
+        ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
+
+    async def test_club_update_allowed_for_owner(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = {
+            "id": "club-1",
+            "name": "Test Club",
+            "members": [{"discord_id": "111", "role": "owner"}],
+        }
+        self.bot.api.update_club.return_value = {"success": True}
+        await self.commands["club_update"]["func"](ctx, args="--name Updated")
+        self.bot.api.update_club.assert_called_once()
+
+    async def test_club_update_denied_when_no_members_in_club(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = {
+            "id": "club-1",
+            "name": "Test Club",
+            "members": [],
+        }
+        await self.commands["club_update"]["func"](ctx, args="--name X")
         ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
 
 
@@ -236,6 +288,46 @@ class TestClubCommands(unittest.IsolatedAsyncioTestCase):
         await self.commands["club_delete"]["func"](ctx)
         self.bot.api.delete_club.assert_not_called()
 
+    async def test_club_delete_no_club_in_channel(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.side_effect = [self.club, None]
+        await self.commands["club_delete"]["func"](ctx)
+        ctx.send.assert_called_with("❌ No book club found in this channel.")
+
+    async def test_club_create_no_club_in_channel(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.create_club.side_effect = APIError("failed")
+        await self.commands["club_create"]["func"](ctx, name="New Club")
+        self.assertIn("❌", ctx.send.call_args.args[0])
+
+    async def test_club_update_both_flags(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_club.return_value = {"success": True}
+        await self.commands["club_update"]["func"](ctx, args="--name NewName --channel 555")
+        self.bot.api.update_club.assert_called_once()
+        call_args = self.bot.api.update_club.call_args[0][1]
+        self.assertIn("name", call_args)
+        self.assertIn("discord_channel", call_args)
+
+    async def test_club_update_api_error(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_club.side_effect = APIError("update failed")
+        await self.commands["club_update"]["func"](ctx, args="--name X")
+        self.assertIn("❌", ctx.send.call_args.args[0])
+
+    async def test_club_delete_api_error(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        confirm_msg = MagicMock()
+        confirm_msg.content = "y"
+        self.bot.wait_for.return_value = confirm_msg
+        self.bot.api.delete_club.side_effect = APIError("delete failed")
+        await self.commands["club_delete"]["func"](ctx)
+        self.assertIn("❌", ctx.send.call_args_list[-1].args[0])
+
 
 class TestMemberCommands(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
@@ -298,6 +390,38 @@ class TestMemberCommands(unittest.IsolatedAsyncioTestCase):
         await self.commands["member_role"]["func"](ctx, 42, "superadmin")
         ctx.send.assert_called_with("❌ Role must be `admin` or `member`.")
         self.bot.api.update_member.assert_not_called()
+
+    async def test_member_add_no_club_in_channel(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.side_effect = [self.club, None]
+        new_member = MagicMock()
+        new_member.id = "222"
+        new_member.display_name = "Alice"
+        await self.commands["member_add"]["func"](ctx, new_member)
+        ctx.send.assert_called_with("❌ No book club found in this channel.")
+
+    async def test_member_role_no_club_in_channel(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.side_effect = [self.club, None]
+        await self.commands["member_role"]["func"](ctx, 42, "admin")
+        ctx.send.assert_called_with("❌ No book club found in this channel.")
+
+    async def test_member_role_api_error(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_member.side_effect = APIError("update failed")
+        await self.commands["member_role"]["func"](ctx, 42, "admin")
+        self.assertIn("❌", ctx.send.call_args.args[0])
+
+    async def test_member_remove_api_error(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        confirm_msg = MagicMock()
+        confirm_msg.content = "y"
+        self.bot.wait_for.return_value = confirm_msg
+        self.bot.api.delete_member.side_effect = APIError("delete failed")
+        await self.commands["member_remove"]["func"](ctx, 42)
+        self.assertIn("❌", ctx.send.call_args_list[-1].args[0])
 
 
 class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
@@ -370,6 +494,45 @@ class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
         self.bot.wait_for.return_value = confirm_msg
         await self.commands["session_delete"]["func"](ctx)
         self.bot.api.delete_session.assert_not_called()
+
+    async def test_session_create_no_club_in_channel(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.side_effect = [self.club, None]
+        await self.commands["session_create"]["func"](ctx, "Dune", author="Frank Herbert")
+        ctx.send.assert_called_with("❌ No book club found in this channel.")
+
+    async def test_session_delete_no_club_in_channel(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.side_effect = [self.club, None]
+        await self.commands["session_delete"]["func"](ctx)
+        ctx.send.assert_called_with("❌ No active session found in this channel.")
+
+    async def test_session_update_both_flags(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_session.return_value = {"success": True}
+        await self.commands["session_update"]["func"](ctx, args='--due-date 2026-06-01 --book "New Book|New Author"')
+        self.bot.api.update_session.assert_called_once()
+        call_args = self.bot.api.update_session.call_args[0][1]
+        self.assertIn("due_date", call_args)
+        self.assertIn("book", call_args)
+
+    async def test_session_update_api_error(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_session.side_effect = APIError("update failed")
+        await self.commands["session_update"]["func"](ctx, args="--due-date 2026-06-01")
+        self.assertIn("❌", ctx.send.call_args.args[0])
+
+    async def test_session_delete_api_error(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        confirm_msg = MagicMock()
+        confirm_msg.content = "y"
+        self.bot.wait_for.return_value = confirm_msg
+        self.bot.api.delete_session.side_effect = APIError("delete failed")
+        await self.commands["session_delete"]["func"](ctx)
+        self.assertIn("❌", ctx.send.call_args_list[-1].args[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -3,130 +3,374 @@ Tests for admin commands
 """
 import unittest
 from unittest.mock import patch, MagicMock, AsyncMock, mock_open
-import os
 
 from cogs.admin_commands import setup_admin_commands
+from api.bookclub_api import APIError
 
 
-class TestAdminCommands(unittest.IsolatedAsyncioTestCase):
-    """Test cases for admin commands - PROPERLY ASYNC"""
+def _make_bot():
+    """Creates a mock bot with api and wait_for."""
+    bot = MagicMock()
+    bot.api = MagicMock()
+    bot.wait_for = AsyncMock()
+    commands = {}
 
+    def mock_command(**kwargs):
+        def decorator(func):
+            commands[kwargs.get("name")] = {"func": func, "kwargs": kwargs}
+            return func
+        return decorator
+
+    bot.command = mock_command
+    setup_admin_commands(bot)
+    return bot, commands
+
+
+def _make_ctx(*, is_owner=True, author_id="111", channel_id="999", guild_id="888"):
+    """Creates a mock command context."""
+    ctx = AsyncMock()
+    ctx.send = AsyncMock()
+    ctx.author.id = author_id
+    ctx.channel.id = channel_id
+    ctx.guild.id = guild_id
+    ctx.guild.name = "Test Server"
+    ctx.guild.owner = ctx.author if is_owner else MagicMock()
+    return ctx
+
+
+def _club_with_admin(author_id, club_id="club-1", session_id="sess-1"):
+    """Returns club data where the author is an admin."""
+    return {
+        "id": club_id,
+        "name": "Test Club",
+        "discord_channel": "999",
+        "members": [{"discord_id": str(author_id), "role": "admin"}],
+        "active_session": {"id": session_id, "book": {"title": "Dune", "author": "Herbert"}},
+    }
+
+
+class TestVersionCommand(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        """Set up common test fixtures"""
-        # Create a mock bot
-        self.bot = MagicMock()
+        self.bot, self.commands = _make_bot()
 
-        # Store the registered commands
-        self.commands = {}
-
-        # Mock the bot.command decorator
-        def mock_command(**kwargs):
-            def decorator(func):
-                # Store the command and its properties
-                self.commands[kwargs.get('name')] = {
-                    'func': func,
-                    'kwargs': kwargs
-                }
-                return func
-            return decorator
-
-        self.bot.command = mock_command
-
-        # Register the commands
-        setup_admin_commands(self.bot)
-
-        # Verify command was registered
-        self.assertIn('version', self.commands)
-
-    async def test_version_command_success(self):
-        """Test the version command with successful version extraction"""
-        # Create mock context
-        ctx = AsyncMock()
-        ctx.send = AsyncMock()
-
-        # Mock setup.py content
-        setup_content = '''
-from setuptools import setup, find_packages
-
-setup(
-    name="quill-bot",
-    version="0.0.1",
-    description="A Discord bot for book clubs",
-    packages=find_packages(),
-)
-'''
-
-        with patch('builtins.open', mock_open(read_data=setup_content)):
-            with patch('os.path.join', return_value='setup.py'):
-                with patch('os.path.dirname', return_value='/mock/path'):
-                    # Call the version command
-                    await self.commands['version']['func'](ctx)
-
-        # Verify that ctx.send was called with an embed
+    async def test_version_success(self):
+        ctx = _make_ctx()
+        setup_content = 'setup(name="quill-bot", version="0.0.1")'
+        with patch("builtins.open", mock_open(read_data=setup_content)):
+            with patch("os.path.join", return_value="setup.py"):
+                with patch("os.path.dirname", return_value="/mock"):
+                    await self.commands["version"]["func"](ctx)
         ctx.send.assert_called_once()
-        call_args = ctx.send.call_args
-        self.assertIn('embed', call_args.kwargs)
+        self.assertIn("embed", ctx.send.call_args.kwargs)
 
-    async def test_version_command_no_version_found(self):
-        """Test the version command when version is not found in setup.py"""
-        # Create mock context
-        ctx = AsyncMock()
-        ctx.send = AsyncMock()
-
-        # Mock setup.py content without version
-        setup_content = '''
-from setuptools import setup
-
-setup(
-    name="quill-bot",
-)
-'''
-
-        with patch('builtins.open', mock_open(read_data=setup_content)):
-            with patch('os.path.join', return_value='setup.py'):
-                with patch('os.path.dirname', return_value='/mock/path'):
-                    # Call the version command
-                    await self.commands['version']['func'](ctx)
-
-        # Verify that ctx.send was called with an error embed
+    async def test_version_not_found(self):
+        ctx = _make_ctx()
+        with patch("builtins.open", mock_open(read_data="setup(name='quill-bot')")):
+            with patch("os.path.join", return_value="setup.py"):
+                with patch("os.path.dirname", return_value="/mock"):
+                    await self.commands["version"]["func"](ctx)
         ctx.send.assert_called_once()
-        call_args = ctx.send.call_args
-        self.assertIn('embed', call_args.kwargs)
 
-    async def test_version_command_file_not_found(self):
-        """Test the version command when setup.py is not found"""
-        # Create mock context
-        ctx = AsyncMock()
-        ctx.send = AsyncMock()
-
-        with patch('builtins.open', side_effect=FileNotFoundError("setup.py not found")):
-            with patch('os.path.join', return_value='setup.py'):
-                with patch('os.path.dirname', return_value='/mock/path'):
-                    # Call the version command
-                    await self.commands['version']['func'](ctx)
-
-        # Verify that ctx.send was called with an error embed
+    async def test_version_file_error(self):
+        ctx = _make_ctx()
+        with patch("builtins.open", side_effect=FileNotFoundError()):
+            with patch("os.path.join", return_value="setup.py"):
+                with patch("os.path.dirname", return_value="/mock"):
+                    await self.commands["version"]["func"](ctx)
         ctx.send.assert_called_once()
-        call_args = ctx.send.call_args
-        self.assertIn('embed', call_args.kwargs)
 
-    async def test_version_command_general_exception(self):
-        """Test the version command with a general exception"""
-        # Create mock context
-        ctx = AsyncMock()
-        ctx.send = AsyncMock()
 
-        with patch('builtins.open', side_effect=Exception("Unexpected error")):
-            with patch('os.path.join', return_value='setup.py'):
-                with patch('os.path.dirname', return_value='/mock/path'):
-                    # Call the version command
-                    await self.commands['version']['func'](ctx)
+class TestGuildOwnerCheck(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.bot, self.commands = _make_bot()
 
-        # Verify that ctx.send was called with an error embed
+    async def test_server_register_denied_for_non_owner(self):
+        ctx = _make_ctx(is_owner=False)
+        await self.commands["server_register"]["func"](ctx)
+        ctx.send.assert_called_once_with("❌ Only the server owner can use this command.")
+        self.bot.api.register_server.assert_not_called()
+
+    async def test_server_update_denied_for_non_owner(self):
+        ctx = _make_ctx(is_owner=False)
+        await self.commands["server_update"]["func"](ctx, name="New Name")
+        ctx.send.assert_called_once_with("❌ Only the server owner can use this command.")
+
+    async def test_server_delete_denied_for_non_owner(self):
+        ctx = _make_ctx(is_owner=False)
+        await self.commands["server_delete"]["func"](ctx)
+        ctx.send.assert_called_once_with("❌ Only the server owner can use this command.")
+
+
+class TestServerCommands(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.bot, self.commands = _make_bot()
+
+    async def test_server_register_success(self):
+        ctx = _make_ctx()
+        self.bot.api.register_server.return_value = {"success": True}
+        await self.commands["server_register"]["func"](ctx)
+        self.bot.api.register_server.assert_called_once_with("888", "Test Server")
         ctx.send.assert_called_once()
-        call_args = ctx.send.call_args
-        self.assertIn('embed', call_args.kwargs)
+        self.assertIn("embed", ctx.send.call_args.kwargs)
+
+    async def test_server_register_api_error(self):
+        ctx = _make_ctx()
+        self.bot.api.register_server.side_effect = APIError("connection failed")
+        await self.commands["server_register"]["func"](ctx)
+        self.assertIn("❌", ctx.send.call_args.args[0])
+
+    async def test_server_update_success(self):
+        ctx = _make_ctx()
+        self.bot.api.update_server.return_value = {"success": True}
+        await self.commands["server_update"]["func"](ctx, name="Updated Name")
+        self.bot.api.update_server.assert_called_once_with("888", "Updated Name")
+        self.assertIn("embed", ctx.send.call_args.kwargs)
+
+    async def test_server_delete_confirmed(self):
+        ctx = _make_ctx()
+        confirm_msg = MagicMock()
+        confirm_msg.content = "y"
+        self.bot.wait_for.return_value = confirm_msg
+        self.bot.api.delete_server.return_value = {"success": True}
+        await self.commands["server_delete"]["func"](ctx)
+        self.bot.api.delete_server.assert_called_once_with("888")
+
+    async def test_server_delete_cancelled(self):
+        ctx = _make_ctx()
+        confirm_msg = MagicMock()
+        confirm_msg.content = "n"
+        self.bot.wait_for.return_value = confirm_msg
+        await self.commands["server_delete"]["func"](ctx)
+        self.bot.api.delete_server.assert_not_called()
 
 
-if __name__ == '__main__':
+class TestClubAdminCheck(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.bot, self.commands = _make_bot()
+
+    async def test_club_create_denied_when_not_admin(self):
+        ctx = _make_ctx(author_id="999")
+        # Club has a different member as admin
+        self.bot.api.find_club_in_channel.return_value = {
+            "id": "club-1",
+            "name": "Test Club",
+            "members": [{"discord_id": "111", "role": "admin"}],
+        }
+        await self.commands["club_create"]["func"](ctx, name="New Club")
+        ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
+
+    async def test_club_create_denied_when_no_club(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = None
+        await self.commands["club_create"]["func"](ctx, name="New Club")
+        ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
+
+    async def test_club_create_denied_when_role_is_member(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = {
+            "id": "club-1",
+            "name": "Test Club",
+            "members": [{"discord_id": "111", "role": "member"}],
+        }
+        await self.commands["club_create"]["func"](ctx, name="New Club")
+        ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
+
+
+class TestClubCommands(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.bot, self.commands = _make_bot()
+        self.club = _club_with_admin("111")
+
+    async def test_club_create_success(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.create_club.return_value = {"success": True}
+        await self.commands["club_create"]["func"](ctx, name="Sci-Fi Club")
+        self.bot.api.create_club.assert_called_once()
+        self.assertIn("embed", ctx.send.call_args.kwargs)
+
+    async def test_club_create_api_error(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.create_club.side_effect = APIError("server error")
+        await self.commands["club_create"]["func"](ctx, name="Sci-Fi Club")
+        self.assertIn("❌", ctx.send.call_args.args[0])
+
+    async def test_club_update_name_success(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_club.return_value = {"success": True}
+        await self.commands["club_update"]["func"](ctx, args="--name New Name")
+        self.bot.api.update_club.assert_called_once_with("club-1", {"name": "New Name"}, "888")
+
+    async def test_club_update_no_flags(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        await self.commands["club_update"]["func"](ctx, args="--invalid")
+        self.assertIn("❌", ctx.send.call_args.args[0])
+        self.bot.api.update_club.assert_not_called()
+
+    async def test_club_update_no_club_in_channel(self):
+        ctx = _make_ctx(author_id="111")
+        # First call (in _check_club_admin) returns club, second (in command) returns None
+        self.bot.api.find_club_in_channel.side_effect = [self.club, None]
+        await self.commands["club_update"]["func"](ctx, args="--name X")
+        ctx.send.assert_called_with("❌ No book club found in this channel.")
+
+    async def test_club_delete_confirmed(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        confirm_msg = MagicMock()
+        confirm_msg.content = "y"
+        self.bot.wait_for.return_value = confirm_msg
+        self.bot.api.delete_club.return_value = {"success": True}
+        await self.commands["club_delete"]["func"](ctx)
+        self.bot.api.delete_club.assert_called_once_with("club-1", "888")
+
+    async def test_club_delete_cancelled(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        confirm_msg = MagicMock()
+        confirm_msg.content = "n"
+        self.bot.wait_for.return_value = confirm_msg
+        await self.commands["club_delete"]["func"](ctx)
+        self.bot.api.delete_club.assert_not_called()
+
+
+class TestMemberCommands(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.bot, self.commands = _make_bot()
+        self.club = _club_with_admin("111")
+
+    async def test_member_add_success(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.create_member.return_value = {"success": True}
+        new_member = MagicMock()
+        new_member.id = "222"
+        new_member.display_name = "Alice"
+        await self.commands["member_add"]["func"](ctx, new_member)
+        self.bot.api.create_member.assert_called_once_with({
+            "name": "Alice",
+            "discord_id": "222",
+            "clubs": ["club-1"],
+        })
+
+    async def test_member_add_api_error(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.create_member.side_effect = APIError("failed")
+        new_member = MagicMock()
+        new_member.id = "222"
+        new_member.display_name = "Alice"
+        await self.commands["member_add"]["func"](ctx, new_member)
+        self.assertIn("❌", ctx.send.call_args.args[0])
+
+    async def test_member_remove_confirmed(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        confirm_msg = MagicMock()
+        confirm_msg.content = "y"
+        self.bot.wait_for.return_value = confirm_msg
+        self.bot.api.delete_member.return_value = {"success": True}
+        await self.commands["member_remove"]["func"](ctx, 42)
+        self.bot.api.delete_member.assert_called_once_with(42)
+
+    async def test_member_remove_cancelled(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        confirm_msg = MagicMock()
+        confirm_msg.content = "no"
+        self.bot.wait_for.return_value = confirm_msg
+        await self.commands["member_remove"]["func"](ctx, 42)
+        self.bot.api.delete_member.assert_not_called()
+
+    async def test_member_role_admin_success(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_member.return_value = {"success": True}
+        await self.commands["member_role"]["func"](ctx, 42, "admin")
+        self.bot.api.update_member.assert_called_once_with(42, {"club_roles": {"club-1": "admin"}})
+
+    async def test_member_role_invalid_role(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        await self.commands["member_role"]["func"](ctx, 42, "superadmin")
+        ctx.send.assert_called_with("❌ Role must be `admin` or `member`.")
+        self.bot.api.update_member.assert_not_called()
+
+
+class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.bot, self.commands = _make_bot()
+        self.club = _club_with_admin("111")
+
+    async def test_session_create_success(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.create_session.return_value = {"success": True}
+        await self.commands["session_create"]["func"](ctx, "Dune", author="Frank Herbert")
+        self.bot.api.create_session.assert_called_once_with({
+            "club_id": "club-1",
+            "book": {"title": "Dune", "author": "Frank Herbert"},
+        })
+
+    async def test_session_create_api_error(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.create_session.side_effect = APIError("failed")
+        await self.commands["session_create"]["func"](ctx, "Dune", author="Frank Herbert")
+        self.assertIn("❌", ctx.send.call_args.args[0])
+
+    async def test_session_update_due_date(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_session.return_value = {"success": True}
+        await self.commands["session_update"]["func"](ctx, args="--due-date 2026-06-01")
+        self.bot.api.update_session.assert_called_once_with("sess-1", {"due_date": "2026-06-01"})
+
+    async def test_session_update_book(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_session.return_value = {"success": True}
+        await self.commands["session_update"]["func"](ctx, args='--book "Foundation|Isaac Asimov"')
+        self.bot.api.update_session.assert_called_once_with(
+            "sess-1", {"book": {"title": "Foundation", "author": "Isaac Asimov"}}
+        )
+
+    async def test_session_update_no_flags(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        await self.commands["session_update"]["func"](ctx, args="--invalid")
+        self.assertIn("❌", ctx.send.call_args.args[0])
+        self.bot.api.update_session.assert_not_called()
+
+    async def test_session_update_no_active_session(self):
+        ctx = _make_ctx(author_id="111")
+        club_no_session = {**self.club, "active_session": None}
+        self.bot.api.find_club_in_channel.return_value = club_no_session
+        await self.commands["session_update"]["func"](ctx, args="--due-date 2026-06-01")
+        ctx.send.assert_called_with("❌ No active session found in this channel.")
+
+    async def test_session_delete_confirmed(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        confirm_msg = MagicMock()
+        confirm_msg.content = "y"
+        self.bot.wait_for.return_value = confirm_msg
+        self.bot.api.delete_session.return_value = {"success": True}
+        await self.commands["session_delete"]["func"](ctx)
+        self.bot.api.delete_session.assert_called_once_with("sess-1")
+
+    async def test_session_delete_cancelled(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        confirm_msg = MagicMock()
+        confirm_msg.content = "n"
+        self.bot.wait_for.return_value = confirm_msg
+        await self.commands["session_delete"]["func"](ctx)
+        self.bot.api.delete_session.assert_not_called()
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -64,6 +64,24 @@ class TestConfirmFlow(unittest.IsolatedAsyncioTestCase):
         # Should have sent 3 messages: prompt, timeout, and cancellation
         self.assertEqual(ctx.send.call_count, 3)
 
+    async def test_confirm_check_predicate_invoked(self):
+        ctx = _make_ctx()
+
+        async def fake_wait_for(_event, *, timeout=30.0, check=None):
+            msg = MagicMock()
+            msg.author = ctx.author
+            msg.channel = ctx.channel
+            msg.content = "y"
+            check(msg)
+            return msg
+
+        self.bot.wait_for.side_effect = fake_wait_for
+        club = _club_with_admin("111")
+        self.bot.api.find_club_in_channel.return_value = club
+        self.bot.api.delete_club.return_value = {"success": True}
+        await self.commands["club_delete"]["func"](ctx)
+        self.bot.api.delete_club.assert_called_once()
+
 
 class TestVersionCommand(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
@@ -73,8 +91,8 @@ class TestVersionCommand(unittest.IsolatedAsyncioTestCase):
         ctx = _make_ctx()
         setup_content = 'setup(name="quill-bot", version="0.0.1")'
         with patch("builtins.open", mock_open(read_data=setup_content)):
-            with patch("os.path.join", return_value="setup.py"):
-                with patch("os.path.dirname", return_value="/mock"):
+            with patch("cogs.admin_commands.os.path.join", return_value="setup.py"):
+                with patch("cogs.admin_commands.os.path.dirname", return_value="/mock"):
                     await self.commands["version"]["func"](ctx)
         ctx.send.assert_called_once()
         self.assertIn("embed", ctx.send.call_args.kwargs)
@@ -371,6 +389,21 @@ class TestClubCommands(unittest.IsolatedAsyncioTestCase):
         await self.commands["club_delete"]["func"](ctx)
         self.assertIn("❌", ctx.send.call_args_list[-1].args[0])
 
+    async def test_club_create_empty_name(self):
+        ctx = _make_ctx(author_id="111")
+        await self.commands["club_create"]["func"](ctx, args="--channel 999")
+        ctx.send.assert_called_once_with(
+            "❌ Provide a club name: `!club_create <name> [--channel <id>]`"
+        )
+        self.bot.api.create_club.assert_not_called()
+
+    async def test_club_delete_no_permission(self):
+        ctx = _make_ctx(author_id="999", is_owner=False)
+        self.bot.api.find_club_in_channel.return_value = _club_with_admin("111")
+        await self.commands["club_delete"]["func"](ctx)
+        ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
+        self.bot.api.delete_club.assert_not_called()
+
 
 class TestMemberCommands(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
@@ -502,6 +535,30 @@ class TestMemberCommands(unittest.IsolatedAsyncioTestCase):
         await self.commands["member_remove"]["func"](ctx, 42)
         self.assertIn("❌", ctx.send.call_args_list[-1].args[0])
 
+    async def test_member_add_no_permission(self):
+        ctx = _make_ctx(author_id="999", is_owner=False)
+        self.bot.api.find_club_in_channel.return_value = _club_with_admin("111")
+        new_member = MagicMock()
+        new_member.id = "999"
+        new_member.display_name = "Intruder"
+        await self.commands["member_add"]["func"](ctx, new_member)
+        ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
+        self.bot.api.create_member.assert_not_called()
+
+    async def test_member_remove_no_permission(self):
+        ctx = _make_ctx(author_id="999", is_owner=False)
+        self.bot.api.find_club_in_channel.return_value = _club_with_admin("111")
+        await self.commands["member_remove"]["func"](ctx, 42)
+        ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
+        self.bot.api.delete_member.assert_not_called()
+
+    async def test_member_role_no_permission(self):
+        ctx = _make_ctx(author_id="999", is_owner=False)
+        self.bot.api.find_club_in_channel.return_value = _club_with_admin("111")
+        await self.commands["member_role"]["func"](ctx, 42, "admin")
+        ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
+        self.bot.api.update_member.assert_not_called()
+
 
 class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
@@ -612,6 +669,27 @@ class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
         self.bot.api.delete_session.side_effect = APIError("delete failed")
         await self.commands["session_delete"]["func"](ctx)
         self.assertIn("❌", ctx.send.call_args_list[-1].args[0])
+
+    async def test_session_create_no_permission(self):
+        ctx = _make_ctx(author_id="999", is_owner=False)
+        self.bot.api.find_club_in_channel.return_value = _club_with_admin("111")
+        await self.commands["session_create"]["func"](ctx, "Dune", author="Frank Herbert")
+        ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
+        self.bot.api.create_session.assert_not_called()
+
+    async def test_session_update_no_permission(self):
+        ctx = _make_ctx(author_id="999", is_owner=False)
+        self.bot.api.find_club_in_channel.return_value = _club_with_admin("111")
+        await self.commands["session_update"]["func"](ctx, args="--due-date 2026-06-01")
+        ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
+        self.bot.api.update_session.assert_not_called()
+
+    async def test_session_delete_no_permission(self):
+        ctx = _make_ctx(author_id="999", is_owner=False)
+        self.bot.api.find_club_in_channel.return_value = _club_with_admin("111")
+        await self.commands["session_delete"]["func"](ctx)
+        ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
+        self.bot.api.delete_session.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -344,9 +344,10 @@ class TestMemberCommands(unittest.IsolatedAsyncioTestCase):
         self.bot, self.commands = _make_bot()
         self.club = _club_with_admin("111")
 
-    async def test_member_add_success(self):
+    async def test_member_add_new_member(self):
         ctx = _make_ctx(author_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_member_by_discord_id.return_value = None
         self.bot.api.create_member.return_value = {"success": True}
         new_member = MagicMock()
         new_member.id = "222"
@@ -358,9 +359,44 @@ class TestMemberCommands(unittest.IsolatedAsyncioTestCase):
             "clubs": ["club-1"],
         })
 
+    async def test_member_add_existing_member_joins_new_club(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_member_by_discord_id.return_value = {
+            "id": 99,
+            "name": "Alice",
+            "discord_id": "222",
+            "clubs": [{"id": "other-club"}],
+        }
+        self.bot.api.update_member.return_value = {"success": True}
+        new_member = MagicMock()
+        new_member.id = "222"
+        new_member.display_name = "Alice"
+        await self.commands["member_add"]["func"](ctx, new_member)
+        self.bot.api.create_member.assert_not_called()
+        self.bot.api.update_member.assert_called_once_with(99, {"clubs": ["other-club", "club-1"]})
+
+    async def test_member_add_already_in_club(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_member_by_discord_id.return_value = {
+            "id": 99,
+            "name": "Alice",
+            "discord_id": "222",
+            "clubs": [{"id": "club-1"}],
+        }
+        new_member = MagicMock()
+        new_member.id = "222"
+        new_member.display_name = "Alice"
+        await self.commands["member_add"]["func"](ctx, new_member)
+        self.bot.api.create_member.assert_not_called()
+        self.bot.api.update_member.assert_not_called()
+        self.assertIn("already a member", ctx.send.call_args.args[0])
+
     async def test_member_add_api_error(self):
         ctx = _make_ctx(author_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_member_by_discord_id.return_value = None
         self.bot.api.create_member.side_effect = APIError("failed")
         new_member = MagicMock()
         new_member.id = "222"

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -175,12 +175,22 @@ class TestServerCommands(unittest.IsolatedAsyncioTestCase):
         self.assertIn("❌", ctx.send.call_args.args[0])
 
 
-class TestClubAdminCheck(unittest.IsolatedAsyncioTestCase):
+class TestCanManageClubs(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.bot, self.commands = _make_bot()
 
-    async def test_club_create_denied_when_not_admin(self):
-        ctx = _make_ctx(author_id="999")
+    async def test_guild_owner_can_create_club_without_being_admin(self):
+        """Guild owner should be able to create a club even if not a club admin."""
+        ctx = _make_ctx(author_id="111", is_owner=True)
+        # No club exists yet
+        self.bot.api.find_club_in_channel.return_value = None
+        self.bot.api.create_club.return_value = {"success": True}
+        await self.commands["club_create"]["func"](ctx, name="New Club")
+        # Should succeed because user is guild owner
+        self.bot.api.create_club.assert_called_once()
+
+    async def test_non_owner_denied_when_not_admin(self):
+        ctx = _make_ctx(author_id="999", is_owner=False)
         # Club has a different member as admin
         self.bot.api.find_club_in_channel.return_value = {
             "id": "club-1",
@@ -191,13 +201,13 @@ class TestClubAdminCheck(unittest.IsolatedAsyncioTestCase):
         ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
 
     async def test_club_create_denied_when_no_club(self):
-        ctx = _make_ctx(author_id="111")
+        ctx = _make_ctx(author_id="111", is_owner=False)
         self.bot.api.find_club_in_channel.return_value = None
         await self.commands["club_create"]["func"](ctx, name="New Club")
         ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
 
     async def test_club_create_denied_when_role_is_member(self):
-        ctx = _make_ctx(author_id="111")
+        ctx = _make_ctx(author_id="111", is_owner=False)
         self.bot.api.find_club_in_channel.return_value = {
             "id": "club-1",
             "name": "Test Club",
@@ -218,7 +228,7 @@ class TestClubAdminCheck(unittest.IsolatedAsyncioTestCase):
         self.bot.api.update_club.assert_called_once()
 
     async def test_club_update_denied_when_no_members_in_club(self):
-        ctx = _make_ctx(author_id="111")
+        ctx = _make_ctx(author_id="111", is_owner=False)
         self.bot.api.find_club_in_channel.return_value = {
             "id": "club-1",
             "name": "Test Club",
@@ -263,11 +273,11 @@ class TestClubCommands(unittest.IsolatedAsyncioTestCase):
         self.bot.api.update_club.assert_not_called()
 
     async def test_club_update_no_club_in_channel(self):
-        ctx = _make_ctx(author_id="111")
-        # First call (in _check_club_admin) returns club, second (in command) returns None
-        self.bot.api.find_club_in_channel.side_effect = [self.club, None]
+        ctx = _make_ctx(author_id="111", is_owner=True)
+        # Guild owner, but no club in channel
+        self.bot.api.find_club_in_channel.return_value = None
         await self.commands["club_update"]["func"](ctx, args="--name X")
-        ctx.send.assert_called_with("❌ No book club found in this channel.")
+        ctx.send.assert_called_once_with("❌ No book club found in this channel.")
 
     async def test_club_delete_confirmed(self):
         ctx = _make_ctx(author_id="111")
@@ -289,10 +299,10 @@ class TestClubCommands(unittest.IsolatedAsyncioTestCase):
         self.bot.api.delete_club.assert_not_called()
 
     async def test_club_delete_no_club_in_channel(self):
-        ctx = _make_ctx(author_id="111")
-        self.bot.api.find_club_in_channel.side_effect = [self.club, None]
+        ctx = _make_ctx(author_id="111", is_owner=True)
+        self.bot.api.find_club_in_channel.return_value = None
         await self.commands["club_delete"]["func"](ctx)
-        ctx.send.assert_called_with("❌ No book club found in this channel.")
+        ctx.send.assert_called_once_with("❌ No book club found in this channel.")
 
     async def test_club_create_no_club_in_channel(self):
         ctx = _make_ctx(author_id="111")
@@ -392,19 +402,19 @@ class TestMemberCommands(unittest.IsolatedAsyncioTestCase):
         self.bot.api.update_member.assert_not_called()
 
     async def test_member_add_no_club_in_channel(self):
-        ctx = _make_ctx(author_id="111")
-        self.bot.api.find_club_in_channel.side_effect = [self.club, None]
+        ctx = _make_ctx(author_id="111", is_owner=True)
+        self.bot.api.find_club_in_channel.return_value = None
         new_member = MagicMock()
         new_member.id = "222"
         new_member.display_name = "Alice"
         await self.commands["member_add"]["func"](ctx, new_member)
-        ctx.send.assert_called_with("❌ No book club found in this channel.")
+        ctx.send.assert_called_once_with("❌ No book club found in this channel.")
 
     async def test_member_role_no_club_in_channel(self):
-        ctx = _make_ctx(author_id="111")
-        self.bot.api.find_club_in_channel.side_effect = [self.club, None]
+        ctx = _make_ctx(author_id="111", is_owner=True)
+        self.bot.api.find_club_in_channel.return_value = None
         await self.commands["member_role"]["func"](ctx, 42, "admin")
-        ctx.send.assert_called_with("❌ No book club found in this channel.")
+        ctx.send.assert_called_once_with("❌ No book club found in this channel.")
 
     async def test_member_role_api_error(self):
         ctx = _make_ctx(author_id="111")
@@ -496,16 +506,16 @@ class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
         self.bot.api.delete_session.assert_not_called()
 
     async def test_session_create_no_club_in_channel(self):
-        ctx = _make_ctx(author_id="111")
-        self.bot.api.find_club_in_channel.side_effect = [self.club, None]
+        ctx = _make_ctx(author_id="111", is_owner=True)
+        self.bot.api.find_club_in_channel.return_value = None
         await self.commands["session_create"]["func"](ctx, "Dune", author="Frank Herbert")
-        ctx.send.assert_called_with("❌ No book club found in this channel.")
+        ctx.send.assert_called_once_with("❌ No book club found in this channel.")
 
     async def test_session_delete_no_club_in_channel(self):
-        ctx = _make_ctx(author_id="111")
-        self.bot.api.find_club_in_channel.side_effect = [self.club, None]
+        ctx = _make_ctx(author_id="111", is_owner=True)
+        self.bot.api.find_club_in_channel.return_value = None
         await self.commands["session_delete"]["func"](ctx)
-        ctx.send.assert_called_with("❌ No active session found in this channel.")
+        ctx.send.assert_called_once_with("❌ No active session found in this channel.")
 
     async def test_session_update_both_flags(self):
         ctx = _make_ctx(author_id="111")

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -182,11 +182,12 @@ class TestCanManageClubs(unittest.IsolatedAsyncioTestCase):
     async def test_guild_owner_can_create_club_without_being_admin(self):
         """Guild owner should be able to create a club even if not a club admin."""
         ctx = _make_ctx(author_id="111", is_owner=True)
-        # No club exists yet
-        self.bot.api.find_club_in_channel.return_value = None
+        club = _club_with_admin("111")
+        self.bot.api.find_club_in_channel.return_value = club
         self.bot.api.create_club.return_value = {"success": True}
-        await self.commands["club_create"]["func"](ctx, name="New Club")
-        # Should succeed because user is guild owner
+        self.bot.api.get_member_by_discord_id.return_value = None
+        self.bot.api.create_member.return_value = {"success": True}
+        await self.commands["club_create"]["func"](ctx, args="New Club")
         self.bot.api.create_club.assert_called_once()
 
     async def test_non_owner_denied_when_not_admin(self):
@@ -197,13 +198,13 @@ class TestCanManageClubs(unittest.IsolatedAsyncioTestCase):
             "name": "Test Club",
             "members": [{"discord_id": "111", "role": "admin"}],
         }
-        await self.commands["club_create"]["func"](ctx, name="New Club")
+        await self.commands["club_create"]["func"](ctx, args="New Club")
         ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
 
     async def test_club_create_denied_when_no_club(self):
         ctx = _make_ctx(author_id="111", is_owner=False)
         self.bot.api.find_club_in_channel.return_value = None
-        await self.commands["club_create"]["func"](ctx, name="New Club")
+        await self.commands["club_create"]["func"](ctx, args="New Club")
         ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
 
     async def test_club_create_denied_when_role_is_member(self):
@@ -213,7 +214,7 @@ class TestCanManageClubs(unittest.IsolatedAsyncioTestCase):
             "name": "Test Club",
             "members": [{"discord_id": "111", "role": "member"}],
         }
-        await self.commands["club_create"]["func"](ctx, name="New Club")
+        await self.commands["club_create"]["func"](ctx, args="New Club")
         ctx.send.assert_called_once_with("❌ You need to be a club admin or owner to use this command.")
 
     async def test_club_update_allowed_for_owner(self):
@@ -247,7 +248,9 @@ class TestClubCommands(unittest.IsolatedAsyncioTestCase):
         ctx = _make_ctx(author_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.create_club.return_value = {"success": True}
-        await self.commands["club_create"]["func"](ctx, name="Sci-Fi Club")
+        self.bot.api.get_member_by_discord_id.return_value = None
+        self.bot.api.create_member.return_value = {"success": True}
+        await self.commands["club_create"]["func"](ctx, args="Sci-Fi Club")
         self.bot.api.create_club.assert_called_once()
         self.assertIn("embed", ctx.send.call_args.kwargs)
 
@@ -255,7 +258,7 @@ class TestClubCommands(unittest.IsolatedAsyncioTestCase):
         ctx = _make_ctx(author_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.create_club.side_effect = APIError("server error")
-        await self.commands["club_create"]["func"](ctx, name="Sci-Fi Club")
+        await self.commands["club_create"]["func"](ctx, args="Sci-Fi Club")
         self.assertIn("❌", ctx.send.call_args.args[0])
 
     async def test_club_update_name_success(self):
@@ -277,7 +280,7 @@ class TestClubCommands(unittest.IsolatedAsyncioTestCase):
         # Guild owner, but no club in channel
         self.bot.api.find_club_in_channel.return_value = None
         await self.commands["club_update"]["func"](ctx, args="--name X")
-        ctx.send.assert_called_once_with("❌ No book club found in this channel.")
+        ctx.send.assert_called_once_with("❌ No book club found in that channel.")
 
     async def test_club_delete_confirmed(self):
         ctx = _make_ctx(author_id="111")
@@ -302,24 +305,54 @@ class TestClubCommands(unittest.IsolatedAsyncioTestCase):
         ctx = _make_ctx(author_id="111", is_owner=True)
         self.bot.api.find_club_in_channel.return_value = None
         await self.commands["club_delete"]["func"](ctx)
-        ctx.send.assert_called_once_with("❌ No book club found in this channel.")
+        ctx.send.assert_called_once_with("❌ No book club found in that channel.")
 
-    async def test_club_create_no_club_in_channel(self):
+    async def test_club_create_api_error_on_create(self):
         ctx = _make_ctx(author_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.create_club.side_effect = APIError("failed")
-        await self.commands["club_create"]["func"](ctx, name="New Club")
+        await self.commands["club_create"]["func"](ctx, args="New Club")
         self.assertIn("❌", ctx.send.call_args.args[0])
+
+    async def test_club_create_owner_assigned_existing_member(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.create_club.return_value = {"success": True}
+        self.bot.api.get_member_by_discord_id.return_value = {
+            "id": 99, "clubs": [{"id": "other-club"}]
+        }
+        self.bot.api.update_member.return_value = {"success": True}
+        await self.commands["club_create"]["func"](ctx, args="Sci-Fi Club")
+        self.bot.api.update_member.assert_called()
+        call_kwargs = self.bot.api.update_member.call_args[0][1]
+        self.assertEqual(call_kwargs["club_roles"], {"club-1": "owner"})
+
+    async def test_club_create_with_channel_flag(self):
+        ctx = _make_ctx(author_id="111", is_owner=True)
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.create_club.return_value = {"success": True}
+        self.bot.api.get_member_by_discord_id.return_value = None
+        self.bot.api.create_member.return_value = {"success": True}
+        await self.commands["club_create"]["func"](ctx, args="Sci-Fi Club --channel 123456")
+        call_args = self.bot.api.create_club.call_args[0][0]
+        self.assertEqual(call_args["discord_channel"], "123456")
 
     async def test_club_update_both_flags(self):
         ctx = _make_ctx(author_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.update_club.return_value = {"success": True}
-        await self.commands["club_update"]["func"](ctx, args="--name NewName --channel 555")
+        await self.commands["club_update"]["func"](ctx, args="--name NewName --new-channel 555")
         self.bot.api.update_club.assert_called_once()
         call_args = self.bot.api.update_club.call_args[0][1]
         self.assertIn("name", call_args)
         self.assertIn("discord_channel", call_args)
+
+    async def test_club_update_with_channel_targeting(self):
+        ctx = _make_ctx(author_id="111", is_owner=True)
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_club.return_value = {"success": True}
+        await self.commands["club_update"]["func"](ctx, args="--name NewName --channel 123456")
+        self.bot.api.find_club_in_channel.assert_called_with("123456", "888")
 
     async def test_club_update_api_error(self):
         ctx = _make_ctx(author_id="111")
@@ -444,13 +477,13 @@ class TestMemberCommands(unittest.IsolatedAsyncioTestCase):
         new_member.id = "222"
         new_member.display_name = "Alice"
         await self.commands["member_add"]["func"](ctx, new_member)
-        ctx.send.assert_called_once_with("❌ No book club found in this channel.")
+        ctx.send.assert_called_once_with("❌ No book club found in that channel.")
 
     async def test_member_role_no_club_in_channel(self):
         ctx = _make_ctx(author_id="111", is_owner=True)
         self.bot.api.find_club_in_channel.return_value = None
         await self.commands["member_role"]["func"](ctx, 42, "admin")
-        ctx.send.assert_called_once_with("❌ No book club found in this channel.")
+        ctx.send.assert_called_once_with("❌ No book club found in that channel.")
 
     async def test_member_role_api_error(self):
         ctx = _make_ctx(author_id="111")
@@ -520,7 +553,7 @@ class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
         club_no_session = {**self.club, "active_session": None}
         self.bot.api.find_club_in_channel.return_value = club_no_session
         await self.commands["session_update"]["func"](ctx, args="--due-date 2026-06-01")
-        ctx.send.assert_called_with("❌ No active session found in this channel.")
+        ctx.send.assert_called_with("❌ No active session found in that channel.")
 
     async def test_session_delete_confirmed(self):
         ctx = _make_ctx(author_id="111")
@@ -545,13 +578,13 @@ class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
         ctx = _make_ctx(author_id="111", is_owner=True)
         self.bot.api.find_club_in_channel.return_value = None
         await self.commands["session_create"]["func"](ctx, "Dune", author="Frank Herbert")
-        ctx.send.assert_called_once_with("❌ No book club found in this channel.")
+        ctx.send.assert_called_once_with("❌ No book club found in that channel.")
 
     async def test_session_delete_no_club_in_channel(self):
         ctx = _make_ctx(author_id="111", is_owner=True)
         self.bot.api.find_club_in_channel.return_value = None
         await self.commands["session_delete"]["func"](ctx)
-        ctx.send.assert_called_once_with("❌ No active session found in this channel.")
+        ctx.send.assert_called_once_with("❌ No active session found in that channel.")
 
     async def test_session_update_both_flags(self):
         ctx = _make_ctx(author_id="111")

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -200,11 +200,9 @@ class TestCanManageClubs(unittest.IsolatedAsyncioTestCase):
     async def test_guild_owner_can_create_club_without_being_admin(self):
         """Guild owner should be able to create a club even if not a club admin."""
         ctx = _make_ctx(author_id="111", is_owner=True)
-        club = _club_with_admin("111")
-        self.bot.api.find_club_in_channel.return_value = club
         self.bot.api.create_club.return_value = {"success": True}
         self.bot.api.get_member_by_discord_id.return_value = None
-        self.bot.api.create_member.return_value = {"success": True}
+        self.bot.api.create_member.return_value = {"member": {"id": 1, "name": "Owner"}}
         await self.commands["club_create"]["func"](ctx, args="New Club")
         self.bot.api.create_club.assert_called_once()
 
@@ -264,17 +262,26 @@ class TestClubCommands(unittest.IsolatedAsyncioTestCase):
 
     async def test_club_create_success(self):
         ctx = _make_ctx(author_id="111")
-        self.bot.api.find_club_in_channel.return_value = self.club
-        self.bot.api.create_club.return_value = {"success": True}
         self.bot.api.get_member_by_discord_id.return_value = None
-        self.bot.api.create_member.return_value = {"success": True}
+        self.bot.api.create_member.return_value = {"member": {"id": 1, "name": "Owner"}}
+        self.bot.api.create_club.return_value = {"success": True}
         await self.commands["club_create"]["func"](ctx, args="Sci-Fi Club")
-        self.bot.api.create_club.assert_called_once()
+        call_payload = self.bot.api.create_club.call_args[0][0]
+        self.assertEqual(call_payload["members"], [{"id": 1, "name": "Owner"}])
         self.assertIn("embed", ctx.send.call_args.kwargs)
+
+    async def test_club_create_success_existing_member(self):
+        ctx = _make_ctx(author_id="111")
+        self.bot.api.get_member_by_discord_id.return_value = {"id": 99, "name": "Alice"}
+        self.bot.api.create_club.return_value = {"success": True}
+        await self.commands["club_create"]["func"](ctx, args="Sci-Fi Club")
+        call_payload = self.bot.api.create_club.call_args[0][0]
+        self.assertEqual(call_payload["members"], [{"id": 99, "name": "Alice"}])
+        self.bot.api.create_member.assert_not_called()
 
     async def test_club_create_api_error(self):
         ctx = _make_ctx(author_id="111")
-        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_member_by_discord_id.return_value = {"id": 99, "name": "Alice"}
         self.bot.api.create_club.side_effect = APIError("server error")
         await self.commands["club_create"]["func"](ctx, args="Sci-Fi Club")
         self.assertIn("❌", ctx.send.call_args.args[0])
@@ -327,30 +334,25 @@ class TestClubCommands(unittest.IsolatedAsyncioTestCase):
 
     async def test_club_create_api_error_on_create(self):
         ctx = _make_ctx(author_id="111")
-        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_member_by_discord_id.return_value = {"id": 99, "name": "Alice"}
         self.bot.api.create_club.side_effect = APIError("failed")
         await self.commands["club_create"]["func"](ctx, args="New Club")
         self.assertIn("❌", ctx.send.call_args.args[0])
 
     async def test_club_create_owner_assigned_existing_member(self):
         ctx = _make_ctx(author_id="111")
-        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_member_by_discord_id.return_value = {"id": 99, "name": "Alice"}
         self.bot.api.create_club.return_value = {"success": True}
-        self.bot.api.get_member_by_discord_id.return_value = {
-            "id": 99, "clubs": [{"id": "other-club"}]
-        }
-        self.bot.api.update_member.return_value = {"success": True}
         await self.commands["club_create"]["func"](ctx, args="Sci-Fi Club")
-        self.bot.api.update_member.assert_called()
-        call_kwargs = self.bot.api.update_member.call_args[0][1]
-        self.assertEqual(call_kwargs["club_roles"], {"club-1": "owner"})
+        call_payload = self.bot.api.create_club.call_args[0][0]
+        self.assertEqual(call_payload["members"][0]["id"], 99)
+        self.bot.api.update_member.assert_not_called()
 
     async def test_club_create_with_channel_flag(self):
         ctx = _make_ctx(author_id="111", is_owner=True)
-        self.bot.api.find_club_in_channel.return_value = self.club
-        self.bot.api.create_club.return_value = {"success": True}
         self.bot.api.get_member_by_discord_id.return_value = None
-        self.bot.api.create_member.return_value = {"success": True}
+        self.bot.api.create_member.return_value = {"member": {"id": 1, "name": "Owner"}}
+        self.bot.api.create_club.return_value = {"success": True}
         await self.commands["club_create"]["func"](ctx, args="Sci-Fi Club --channel 123456")
         call_args = self.bot.api.create_club.call_args[0][0]
         self.assertEqual(call_args["discord_channel"], "123456")

--- a/tests/test_bookclub_api.py
+++ b/tests/test_bookclub_api.py
@@ -356,6 +356,43 @@ class TestBookClubAPI(unittest.TestCase):
             params={"id": 1}
         )
 
+    @patch('requests.get')
+    def test_get_member_by_discord_id_found(self, mock_get):
+        """Test get_member_by_discord_id returns member data when found."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "id": 1,
+            "name": "Alice",
+            "discord_id": "123456789",
+            "clubs": [{"id": "club-1", "name": "Test Club"}]
+        }
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = self.api.get_member_by_discord_id("123456789")
+
+        self.assertEqual(result["name"], "Alice")
+        self.assertEqual(result["discord_id"], "123456789")
+        mock_get.assert_called_once_with(
+            "http://test-url.supabase.co/functions/v1/member",
+            headers=self.api.headers,
+            params={"discord_id": "123456789"}
+        )
+
+    @patch('requests.get')
+    def test_get_member_by_discord_id_not_found(self, mock_get):
+        """Test get_member_by_discord_id returns None on 404."""
+        from requests.exceptions import HTTPError
+        mock_response = Mock()
+        mock_response.status_code = 404
+        http_error = HTTPError(response=mock_response)
+        mock_response.raise_for_status.side_effect = http_error
+        mock_get.return_value = mock_response
+
+        result = self.api.get_member_by_discord_id("nonexistent")
+
+        self.assertIsNone(result)
+
     # Session endpoint tests (unchanged - sessions inherit server context from clubs)
     @patch('requests.get')
     def test_get_session(self, mock_get):


### PR DESCRIPTION
## Summary

- Adds 12 new prefix commands for server, club, member, and session management
- Guild-owner-only gate for server ops (`!server_register/update/delete`); club admin/owner gate for all other ops
- Destructive commands (`!server_delete`, `!club_delete`, `!member_remove`, `!session_delete`) prompt for y/n confirmation
- Permission helper `_check_club_admin` matches caller by `discord_id` against club members
- 35 new unit tests covering happy paths, API errors, auth checks, and y/n flows

## Ticket

[KT-2](https://www.notion.so/17eef3554623808b8a6fd5e05126106a)

## Test plan

- [ ] `!server_register` / `!server_update` / `!server_delete` only work for the Discord guild owner
- [ ] Club, member, and session commands require `role=admin` or `role=owner` in MemberClubs
- [ ] All `_delete` commands send a y/n prompt and abort on anything other than `y`
- [ ] Non-authorized users receive a clear rejection message
- [ ] All new commands have unit tests (`make test` passes)

## Test plan 2

### Server commands (guild owner only):

- [ ] Guild owner: !server_register → should succeed
- [ ] Non-owner: !server_register → should say "❌ Only the server owner can use this command"
- [ ] Guild owner: !server_update New Name → should succeed
- [ ] Guild owner: !server_delete → should prompt "Type y to confirm", then y → should delete; try again with n → should cancel

### Club commands (club admin+ only):

- [ ] Create a club first: !club_create "My Test Club"
- [ ] Admin in that club: !club_update --name "Updated Name" → should succeed
- [ ] Non-admin (or different user): same command → "❌ You need to be a club admin..."
- [ ] Admin: !club_delete → prompt with y → success; try with n → cancel

#### Member commands:

- [ ] Admin: !member_add @ivangarzab → should add and show success
- [ ] Admin: !member_role <member_id> admin → should succeed; try invalid role like !member_role <id> superadmin → "❌ Role must be admin or member"

### Session commands:

- [ ] Admin: !session_create "Dune" Frank Herbert → should create
- [ ] Admin: !session_update --due-date 2026-06-15 → should succeed
- [ ] Admin: !session_delete → prompt, confirm with y → success