### PR TITLE
feat(onboarding): Implement setup flow

### DIFF
--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -91,6 +91,70 @@ def setup_admin_commands(bot):
             )
             await ctx.send(embed=embed)
 
+    # ── Admin Help (guild owner or club admin+) ──────────────────────────────
+
+    @bot.command(name="help", help="Show admin command reference")
+    async def admin_help(ctx: commands.Context):
+        """
+        Display admin command reference for guild owners and club admins.
+        Usage: !help
+        """
+        if not await _can_manage_clubs(ctx):
+            await ctx.send("❌ You need to be a guild owner or club admin to use this command.")
+            return
+
+        embed = create_embed(
+            title="📖 Admin Commands Reference",
+            description="Commands for managing your book club",
+            color_key="info",
+            fields=[
+                {
+                    "name": "🔧 Setup & Server",
+                    "value": (
+                        "`!setup` — First-run wizard: register server and create a club\n"
+                        "`!server_register` — Register this Discord server\n"
+                        "`!server_update <name>` — Update server name\n"
+                        "`!server_delete` — Delete server and all data"
+                    ),
+                    "inline": False
+                },
+                {
+                    "name": "📚 Club Management",
+                    "value": (
+                        "`!club_create <name>` — Create a new book club\n"
+                        "`!club_update [--name <name>] [--new-channel <id>]` — Update club details\n"
+                        "`!club_delete` — Delete the club in this channel"
+                    ),
+                    "inline": False
+                },
+                {
+                    "name": "👥 Member Management",
+                    "value": (
+                        "`!member_add @User` — Add a member to the club\n"
+                        "`!member_remove <id>` — Remove a member\n"
+                        "`!member_role <id> <admin|member>` — Set member role"
+                    ),
+                    "inline": False
+                },
+                {
+                    "name": "📖 Session Management",
+                    "value": (
+                        "`!session_create \"<title>\" <author>` — Create a reading session\n"
+                        "`!session_update [--due-date YYYY-MM-DD] [--book \"<title>|<author>\"]` — Update session\n"
+                        "`!session_delete` — Delete the active session"
+                    ),
+                    "inline": False
+                },
+                {
+                    "name": "ℹ️ Other",
+                    "value": "`!version` — Show bot version",
+                    "inline": False
+                }
+            ],
+            footer="Use a command name for more details (e.g., !club_create --help)"
+        )
+        await ctx.send(embed=embed)
+
     # ── Setup wizard (guild owner only) ──────────────────────────────────────
 
     @bot.command(name="setup", help="First-run wizard: register server and create a book club")

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -93,11 +93,11 @@ def setup_admin_commands(bot):
 
     # ── Admin Help (guild owner or club admin+) ──────────────────────────────
 
-    @bot.command(name="help", help="Show admin command reference")
+    @bot.command(name="admin_help", help="Show admin command reference")
     async def admin_help(ctx: commands.Context):
         """
         Display admin command reference for guild owners and club admins.
-        Usage: !help
+        Usage: !admin_help
         """
         if not await _can_manage_clubs(ctx):
             await ctx.send("❌ You need to be a guild owner or club admin to use this command.")

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -91,6 +91,85 @@ def setup_admin_commands(bot):
             )
             await ctx.send(embed=embed)
 
+    # ── Setup wizard (guild owner only) ──────────────────────────────────────
+
+    @bot.command(name="setup", help="First-run wizard: register server and create a book club")
+    async def setup(ctx: commands.Context):
+        """
+        Guided onboarding for new servers.
+        Usage: !setup
+        """
+        if not _check_guild_owner(ctx):
+            await ctx.send("❌ Only the server owner can run `!setup`.")
+            return
+
+        guild_id = str(ctx.guild.id)
+
+        # Register server (idempotent — inform and continue if already registered)
+        try:
+            bot.api.register_server(guild_id, ctx.guild.name)
+        except APIError as e:
+            if "already" in str(e).lower() or "duplicate" in str(e).lower():
+                await ctx.send("ℹ️ This server is already registered. Continuing to club setup…")
+            else:
+                await ctx.send(f"❌ Failed to register server: {e}")
+                return
+
+        await ctx.send("✅ Server registered! What should I call your book club?")
+
+        def check(m):
+            return m.author == ctx.author and m.channel == ctx.channel
+
+        try:
+            msg = await bot.wait_for("message", timeout=60.0, check=check)
+        except TimeoutError:
+            await ctx.send("⏰ Setup timed out. Run `!setup` again when you're ready.")
+            return
+
+        club_name = msg.content.strip()
+        if not club_name:
+            await ctx.send("❌ Club name can't be empty. Run `!setup` again.")
+            return
+
+        channel_id = str(ctx.channel.id)
+
+        try:
+            existing = bot.api.get_member_by_discord_id(str(ctx.author.id))
+            if existing:
+                caller = {"id": existing["id"], "name": existing["name"]}
+            else:
+                created = bot.api.create_member({
+                    "name": ctx.author.display_name,
+                    "discord_id": str(ctx.author.id),
+                })
+                member_data = created.get("member", created)
+                caller = {"id": member_data["id"], "name": member_data["name"]}
+
+            bot.api.create_club(
+                {"name": club_name, "discord_channel": channel_id, "members": [caller]},
+                guild_id
+            )
+        except APIError as e:
+            await ctx.send(f"❌ Failed to create club: {e}")
+            return
+
+        embed = create_embed(
+            title="🎉 You're all set!",
+            description=(
+                f"**{club_name}** has been created in {ctx.channel.mention}.\n\n"
+                "**Available commands:**\n"
+                "`/session` — view the current reading session\n"
+                "`/book` — see the current book\n"
+                "`/duedate` — check the due date\n"
+                "`/discussions` — view scheduled discussions\n"
+                "`!session_create` — start a new session\n"
+                "`!member_add` — add members to the club"
+            ),
+            color_key="success",
+            footer="Happy reading! 📖"
+        )
+        await ctx.send(embed=embed)
+
     # ── Server commands (guild owner only) ───────────────────────────────────
 
     @bot.command(name="server_register", help="Register this Discord server with the bot")

--- a/events/message_handler.py
+++ b/events/message_handler.py
@@ -39,6 +39,30 @@ def setup_message_handlers(bot):
         await bot.process_commands(message)
 
     @bot.event
+    async def on_guild_join(guild):
+        """Post a welcome embed when the bot joins a new server."""
+        print(f"Joined new guild: {guild.name} ({guild.id})")
+        channel = guild.system_channel
+        if channel is None:
+            channel = next(
+                (c for c in guild.text_channels if c.permissions_for(guild.me).send_messages),
+                None
+            )
+        if channel is None:
+            print(f"[WARN] No writable channel found in guild {guild.id}")
+            return
+        embed = create_embed(
+            title="📚 Hi! I'm Quill, your book club librarian!",
+            description=(
+                "I help book clubs manage reading sessions, track members, and keep discussions organized.\n\n"
+                "**To get started**, run `!setup` in your book club channel and I'll walk you through everything."
+            ),
+            color_key="info",
+            footer="Run !setup to register your server and create your first book club."
+        )
+        await channel.send(embed=embed)
+
+    @bot.event
     async def on_member_join(member):
         """Welcome new members."""
         print(f"New member joined: {member.name}")

--- a/events/message_handler.py
+++ b/events/message_handler.py
@@ -44,10 +44,10 @@ def setup_message_handlers(bot):
         print(f"Joined new guild: {guild.name} ({guild.id})")
         channel = guild.system_channel
         if channel is None:
-            channel = next(
-                (c for c in guild.text_channels if c.permissions_for(guild.me).send_messages),
-                None
-            )
+            for c in guild.text_channels:
+                if c.permissions_for(guild.me).send_messages:
+                    channel = c
+                    break
         if channel is None:
             print(f"[WARN] No writable channel found in guild {guild.id}")
             return

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -701,14 +701,14 @@ class TestAdminHelpCommand(unittest.IsolatedAsyncioTestCase):
     async def test_help_denied_for_non_admin(self):
         ctx = _make_ctx(is_owner=False, author_id="999")
         self.bot.api.find_club_in_channel.return_value = None
-        await self.commands["help"]["func"](ctx)
+        await self.commands["admin_help"]["func"](ctx)
         ctx.send.assert_called_once_with("❌ You need to be a guild owner or club admin to use this command.")
         args = ctx.send.call_args.args[0]
         self.assertNotIn("embed", ctx.send.call_args.kwargs)
 
     async def test_help_allowed_for_guild_owner(self):
         ctx = _make_ctx(is_owner=True)
-        await self.commands["help"]["func"](ctx)
+        await self.commands["admin_help"]["func"](ctx)
         ctx.send.assert_called_once()
         self.assertIn("embed", ctx.send.call_args.kwargs)
         embed = ctx.send.call_args.kwargs["embed"]
@@ -718,7 +718,7 @@ class TestAdminHelpCommand(unittest.IsolatedAsyncioTestCase):
         ctx = _make_ctx(is_owner=False, author_id="111")
         club = _club_with_admin("111")
         self.bot.api.find_club_in_channel.return_value = club
-        await self.commands["help"]["func"](ctx)
+        await self.commands["admin_help"]["func"](ctx)
         ctx.send.assert_called_once()
         self.assertIn("embed", ctx.send.call_args.kwargs)
         embed = ctx.send.call_args.kwargs["embed"]

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -694,6 +694,37 @@ class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
         self.bot.api.delete_session.assert_not_called()
 
 
+class TestAdminHelpCommand(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.bot, self.commands = _make_bot()
+
+    async def test_help_denied_for_non_admin(self):
+        ctx = _make_ctx(is_owner=False, author_id="999")
+        self.bot.api.find_club_in_channel.return_value = None
+        await self.commands["help"]["func"](ctx)
+        ctx.send.assert_called_once_with("❌ You need to be a guild owner or club admin to use this command.")
+        args = ctx.send.call_args.args[0]
+        self.assertNotIn("embed", ctx.send.call_args.kwargs)
+
+    async def test_help_allowed_for_guild_owner(self):
+        ctx = _make_ctx(is_owner=True)
+        await self.commands["help"]["func"](ctx)
+        ctx.send.assert_called_once()
+        self.assertIn("embed", ctx.send.call_args.kwargs)
+        embed = ctx.send.call_args.kwargs["embed"]
+        self.assertIn("Admin Commands", embed.title)
+
+    async def test_help_allowed_for_club_admin(self):
+        ctx = _make_ctx(is_owner=False, author_id="111")
+        club = _club_with_admin("111")
+        self.bot.api.find_club_in_channel.return_value = club
+        await self.commands["help"]["func"](ctx)
+        ctx.send.assert_called_once()
+        self.assertIn("embed", ctx.send.call_args.kwargs)
+        embed = ctx.send.call_args.kwargs["embed"]
+        self.assertIn("Admin Commands", embed.title)
+
+
 class TestSetupCommand(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.bot, self.commands = _make_bot()

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -694,5 +694,103 @@ class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
         self.bot.api.delete_session.assert_not_called()
 
 
+class TestSetupCommand(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.bot, self.commands = _make_bot()
+
+    def _club_name_msg(self, ctx, name="My Book Club"):
+        msg = MagicMock()
+        msg.author = ctx.author
+        msg.channel = ctx.channel
+        msg.content = name
+        return msg
+
+    async def test_setup_denied_for_non_owner(self):
+        ctx = _make_ctx(is_owner=False)
+        await self.commands["setup"]["func"](ctx)
+        ctx.send.assert_called_once_with("❌ Only the server owner can run `!setup`.")
+        self.bot.api.register_server.assert_not_called()
+
+    async def test_setup_happy_path_new_member(self):
+        ctx = _make_ctx()
+        self.bot.api.register_server.return_value = {"success": True}
+        self.bot.api.get_member_by_discord_id.return_value = None
+        self.bot.api.create_member.return_value = {"member": {"id": "m-1", "name": "Owner"}}
+        self.bot.api.create_club.return_value = {"id": "c-1"}
+        self.bot.wait_for.return_value = self._club_name_msg(ctx)
+
+        await self.commands["setup"]["func"](ctx)
+
+        self.bot.api.register_server.assert_called_once_with("888", "Test Server")
+        self.bot.api.create_club.assert_called_once()
+        call_args = self.bot.api.create_club.call_args[0][0]
+        self.assertEqual(call_args["name"], "My Book Club")
+        self.assertEqual(call_args["discord_channel"], "999")
+        # Confirmation embed sent as last message
+        last_call = ctx.send.call_args
+        self.assertIn("embed", last_call.kwargs)
+
+    async def test_setup_happy_path_existing_member(self):
+        ctx = _make_ctx()
+        self.bot.api.register_server.return_value = {"success": True}
+        self.bot.api.get_member_by_discord_id.return_value = {"id": "m-42", "name": "Existing"}
+        self.bot.api.create_club.return_value = {"id": "c-2"}
+        self.bot.wait_for.return_value = self._club_name_msg(ctx, "Readers Circle")
+
+        await self.commands["setup"]["func"](ctx)
+
+        self.bot.api.create_member.assert_not_called()
+        call_args = self.bot.api.create_club.call_args[0][0]
+        self.assertEqual(call_args["name"], "Readers Circle")
+        self.assertEqual(call_args["members"], [{"id": "m-42", "name": "Existing"}])
+
+    async def test_setup_already_registered_server_continues(self):
+        ctx = _make_ctx()
+        self.bot.api.register_server.side_effect = APIError("already registered")
+        self.bot.api.get_member_by_discord_id.return_value = {"id": "m-1", "name": "Owner"}
+        self.bot.api.create_club.return_value = {"id": "c-3"}
+        self.bot.wait_for.return_value = self._club_name_msg(ctx)
+
+        await self.commands["setup"]["func"](ctx)
+
+        # Should inform user and continue to club creation
+        messages = [call.args[0] if call.args else "" for call in ctx.send.call_args_list]
+        self.assertTrue(any("already registered" in m for m in messages))
+        self.bot.api.create_club.assert_called_once()
+
+    async def test_setup_register_server_api_error_stops(self):
+        ctx = _make_ctx()
+        self.bot.api.register_server.side_effect = APIError("connection failed")
+
+        await self.commands["setup"]["func"](ctx)
+
+        self.bot.api.create_club.assert_not_called()
+        last_msg = ctx.send.call_args.args[0]
+        self.assertIn("❌", last_msg)
+
+    async def test_setup_timeout_waiting_for_club_name(self):
+        ctx = _make_ctx()
+        self.bot.api.register_server.return_value = {"success": True}
+        self.bot.wait_for.side_effect = TimeoutError()
+
+        await self.commands["setup"]["func"](ctx)
+
+        self.bot.api.create_club.assert_not_called()
+        last_msg = ctx.send.call_args.args[0]
+        self.assertIn("⏰", last_msg)
+
+    async def test_setup_create_club_api_error(self):
+        ctx = _make_ctx()
+        self.bot.api.register_server.return_value = {"success": True}
+        self.bot.api.get_member_by_discord_id.return_value = {"id": "m-1", "name": "Owner"}
+        self.bot.api.create_club.side_effect = APIError("club creation failed")
+        self.bot.wait_for.return_value = self._club_name_msg(ctx)
+
+        await self.commands["setup"]["func"](ctx)
+
+        last_msg = ctx.send.call_args.args[0]
+        self.assertIn("❌", last_msg)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_message_handler.py
+++ b/tests/test_message_handler.py
@@ -249,7 +249,7 @@ class TestMessageHandler(unittest.IsolatedAsyncioTestCase):
         fallback = AsyncMock()
         perms = MagicMock()
         perms.send_messages = True
-        fallback.permissions_for.return_value = perms
+        fallback.permissions_for = MagicMock(return_value=perms)
         guild.text_channels = [fallback]
 
         on_guild_join = self.handlers['on_guild_join']

--- a/tests/test_message_handler.py
+++ b/tests/test_message_handler.py
@@ -221,6 +221,61 @@ class TestMessageHandler(unittest.IsolatedAsyncioTestCase):
         on_member_join = self.handlers['on_member_join']
         await on_member_join(member)
 
+    async def test_on_guild_join_sends_welcome_to_system_channel(self):
+        """Welcome embed is posted to guild.system_channel when available."""
+        guild = MagicMock()
+        guild.name = "Test Guild"
+        guild.id = 123456
+        system_channel = AsyncMock()
+        guild.system_channel = system_channel
+
+        on_guild_join = self.handlers['on_guild_join']
+        await on_guild_join(guild)
+
+        system_channel.send.assert_called_once()
+        _, kwargs = system_channel.send.call_args
+        self.assertIn('embed', kwargs)
+        embed = kwargs['embed']
+        self.assertIn("Quill", embed.title)
+        self.assertIn("!setup", embed.description)
+
+    async def test_on_guild_join_falls_back_to_first_writable_channel(self):
+        """Falls back to first writable text channel when system_channel is None."""
+        guild = MagicMock()
+        guild.name = "Test Guild"
+        guild.id = 123456
+        guild.system_channel = None
+
+        fallback = AsyncMock()
+        perms = MagicMock()
+        perms.send_messages = True
+        fallback.permissions_for.return_value = perms
+        guild.text_channels = [fallback]
+
+        on_guild_join = self.handlers['on_guild_join']
+        await on_guild_join(guild)
+
+        fallback.send.assert_called_once()
+        _, kwargs = fallback.send.call_args
+        self.assertIn('embed', kwargs)
+
+    async def test_on_guild_join_no_writable_channel(self):
+        """Does not crash when there are no writable channels."""
+        guild = MagicMock()
+        guild.name = "Test Guild"
+        guild.id = 123456
+        guild.system_channel = None
+
+        perms = MagicMock()
+        perms.send_messages = False
+        blocked = MagicMock()
+        blocked.permissions_for.return_value = perms
+        guild.text_channels = [blocked]
+
+        on_guild_join = self.handlers['on_guild_join']
+        await on_guild_join(guild)
+        # No crash; no send called
+        blocked.send.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Adds `on_guild_join` event handler that posts a welcome embed to the server's system channel (falls back to first writable text channel) directing admins to run `!setup`
- Adds `!setup` prefix command (guild-owner only) that registers the server, prompts for a club name, creates the club in the current channel, and sends a confirmation embed with a command cheat sheet
- Covers all new logic with unit tests: 3 tests for `on_guild_join`, 6 tests for `!setup`

## Ticket

[KT-9](https://www.notion.so/17fef355462380bd83d2fcff8fb032c2)

## Test plan

- [ ] Run `make test` — all existing and new tests pass
- [ ] Bot joins a fresh server → welcome embed appears in system channel
- [ ] No system channel set → welcome embed appears in first writable text channel
- [ ] Non-owner runs `!setup` → denied with error message
- [ ] Owner runs `!setup` → server registered, club name prompted, club created, confirmation embed shown
- [ ] Owner runs `!setup` on already-registered server → informed and continues to club creation
- [ ] `!setup` left idle for 60 s → timeout message, no club created