### PR TITLE
Solidify admin commands (KT-139)

### DIFF
--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -208,6 +208,13 @@ def setup_admin_commands(bot):
 
         channel_id = str(interaction.channel_id)
 
+        if bot.api.find_club_in_channel(channel_id, guild_id):
+            await interaction.followup.send(
+                "❌ This channel is already hosting a book club. "
+                "Please use a different channel or delete the existing club first."
+            )
+            return
+
         try:
             existing = bot.api.get_member_by_discord_id(str(interaction.user.id))
             if existing:
@@ -326,6 +333,12 @@ def setup_admin_commands(bot):
             await interaction.followup.send(
                 "❌ You need to be a club admin or owner to use this command.",
                 ephemeral=True
+            )
+            return
+        if club_data:
+            await interaction.followup.send(
+                "❌ This channel is already hosting a book club. "
+                "Please use a different channel or delete the existing club first."
             )
             return
         try:

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -19,13 +19,16 @@ def setup_admin_commands(bot):
         bot: The bot instance
     """
 
-    def _check_guild_owner(interaction: discord.Interaction):
-        """Returns True if the interaction author is the Discord guild owner."""
-        return interaction.user == interaction.guild.owner
+    def _check_guild_admin(interaction: discord.Interaction):
+        """Returns True if the user is the guild owner or has administrator/manage_guild permissions."""
+        if interaction.user == interaction.guild.owner:
+            return True
+        perms = interaction.user.guild_permissions
+        return perms.administrator or perms.manage_guild
 
     def _can_manage_clubs(interaction: discord.Interaction, club_data: dict):
-        """Returns True if user is guild owner OR club admin in club_data."""
-        if _check_guild_owner(interaction):
+        """Returns True if user is guild admin OR club admin in club_data."""
+        if _check_guild_admin(interaction):
             return True
         if not club_data:
             return False
@@ -107,7 +110,7 @@ def setup_admin_commands(bot):
     @bot.tree.command(name="admin_help", description="Show admin command reference")
     async def admin_help(interaction: discord.Interaction):
         """Display admin command reference for guild owners and club admins."""
-        if not _check_guild_owner(interaction):
+        if not _check_guild_admin(interaction):
             channel_id = str(interaction.channel_id)
             club_data = bot.api.find_club_in_channel(channel_id, str(interaction.guild_id))
             if not _can_manage_clubs(interaction, club_data):

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -138,6 +138,7 @@ class TestSetupCommand(unittest.IsolatedAsyncioTestCase):
         interaction = _make_interaction()
         self._mock_message("My Book Club")
         self.bot.api.register_server.return_value = {"success": True}
+        self.bot.api.find_club_in_channel.return_value = None
         self.bot.api.get_member_by_discord_id.return_value = None
         self.bot.api.create_member.return_value = {"member": {"id": 1, "name": "Test User"}}
         self.bot.api.create_club.return_value = {"success": True}
@@ -151,6 +152,7 @@ class TestSetupCommand(unittest.IsolatedAsyncioTestCase):
         interaction = _make_interaction()
         self._mock_message("Reader Club")
         self.bot.api.register_server.return_value = {"success": True}
+        self.bot.api.find_club_in_channel.return_value = None
         self.bot.api.get_member_by_discord_id.return_value = {"id": 99, "name": "Test User"}
         self.bot.api.create_club.return_value = {"success": True}
         await self.commands["setup"]["func"](interaction)
@@ -161,11 +163,23 @@ class TestSetupCommand(unittest.IsolatedAsyncioTestCase):
         interaction = _make_interaction()
         self._mock_message("Reader Club")
         self.bot.api.register_server.side_effect = APIError("server already registered")
+        self.bot.api.find_club_in_channel.return_value = None
         self.bot.api.get_member_by_discord_id.return_value = {"id": 99, "name": "Test User"}
         self.bot.api.create_club.return_value = {"success": True}
         await self.commands["setup"]["func"](interaction)
         # should continue to club creation despite the error
         self.bot.api.create_club.assert_called_once()
+
+    async def test_setup_channel_collision(self):
+        interaction = _make_interaction()
+        self._mock_message("My Book Club")
+        self.bot.api.register_server.return_value = {"success": True}
+        self.bot.api.find_club_in_channel.return_value = {"id": "club-1", "name": "Existing Club"}
+        self.bot.api.get_member_by_discord_id.return_value = {"id": 99, "name": "Test User"}
+        await self.commands["setup"]["func"](interaction)
+        self.bot.api.create_club.assert_not_called()
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.assertIn("already hosting", interaction.followup.send.call_args.args[0])
 
     async def test_setup_register_fails(self):
         interaction = _make_interaction()
@@ -262,6 +276,7 @@ class TestCanManageClubs(unittest.IsolatedAsyncioTestCase):
     async def test_guild_owner_can_create_club_without_being_admin(self):
         """Guild owner should be able to create a club even if not a club admin."""
         interaction = _make_interaction(user_id="111", is_owner=True)
+        self.bot.api.find_club_in_channel.return_value = None
         self.bot.api.create_club.return_value = {"success": True}
         self.bot.api.get_member_by_discord_id.return_value = None
         self.bot.api.create_member.return_value = {"member": {"id": 1, "name": "Owner"}}
@@ -335,6 +350,7 @@ class TestClubCommands(unittest.IsolatedAsyncioTestCase):
 
     async def test_club_create_success(self):
         interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = None
         self.bot.api.get_member_by_discord_id.return_value = None
         self.bot.api.create_member.return_value = {"member": {"id": 1, "name": "Owner"}}
         self.bot.api.create_club.return_value = {"success": True}
@@ -345,12 +361,24 @@ class TestClubCommands(unittest.IsolatedAsyncioTestCase):
 
     async def test_club_create_success_existing_member(self):
         interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = None
         self.bot.api.get_member_by_discord_id.return_value = {"id": 99, "name": "Alice"}
         self.bot.api.create_club.return_value = {"success": True}
         await self.commands["club_create"]["func"](interaction, name="Sci-Fi Club")
         call_payload = self.bot.api.create_club.call_args[0][0]
         self.assertEqual(call_payload["members"], [{"id": 99, "name": "Alice"}])
         self.bot.api.create_member.assert_not_called()
+
+    async def test_club_create_channel_collision(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = {
+            "id": "club-1", "name": "Existing Club",
+            "members": [{"discord_id": "111", "role": "owner"}],
+        }
+        await self.commands["club_create"]["func"](interaction, name="New Club")
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.assertIn("already hosting", interaction.followup.send.call_args.args[0])
+        self.bot.api.create_club.assert_not_called()
 
     async def test_club_create_empty_name(self):
         interaction = _make_interaction(user_id="111")
@@ -360,6 +388,7 @@ class TestClubCommands(unittest.IsolatedAsyncioTestCase):
 
     async def test_club_create_api_error(self):
         interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = None
         self.bot.api.get_member_by_discord_id.return_value = {"id": 99, "name": "Alice"}
         self.bot.api.create_club.side_effect = APIError("server error")
         await self.commands["club_create"]["func"](interaction, name="Sci-Fi Club")

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -43,7 +43,7 @@ def _make_bot():
     return bot, commands
 
 
-def _make_interaction(*, is_owner=True, user_id="111", channel_id="999", guild_id="888"):
+def _make_interaction(*, is_owner=True, user_id="111", channel_id="999", guild_id="888", has_admin_perms=False):
     """Creates a mock interaction."""
     interaction = AsyncMock()
     interaction.response = AsyncMock()
@@ -54,6 +54,9 @@ def _make_interaction(*, is_owner=True, user_id="111", channel_id="999", guild_i
     interaction.user = MagicMock()
     interaction.user.id = int(user_id)
     interaction.user.display_name = "Test User"
+    interaction.user.guild_permissions = MagicMock()
+    interaction.user.guild_permissions.administrator = has_admin_perms
+    interaction.user.guild_permissions.manage_guild = has_admin_perms
     interaction.channel = MagicMock()
     interaction.channel.id = int(channel_id)
     interaction.channel.mention = f"<#{channel_id}>"
@@ -302,6 +305,16 @@ class TestCanManageClubs(unittest.IsolatedAsyncioTestCase):
         self.bot.api.update_club.return_value = {"success": True}
         await self.commands["club_update"]["func"](interaction, name="Updated")
         self.bot.api.update_club.assert_called_once()
+
+    async def test_guild_admin_perms_can_manage_clubs(self):
+        """Users with administrator or manage_guild perms should pass _check_guild_admin."""
+        interaction = _make_interaction(user_id="222", is_owner=False, has_admin_perms=True)
+        self.bot.api.find_club_in_channel.return_value = None
+        self.bot.api.get_member_by_discord_id.return_value = None
+        self.bot.api.create_member.return_value = {"member": {"id": 2, "name": "Admin User"}}
+        self.bot.api.create_club.return_value = {"success": True}
+        await self.commands["club_create"]["func"](interaction, name="New Club")
+        self.bot.api.create_club.assert_called_once()
 
     async def test_club_update_denied_when_no_members_in_club(self):
         interaction = _make_interaction(user_id="111", is_owner=False)
@@ -762,6 +775,12 @@ class TestAdminHelpCommand(unittest.IsolatedAsyncioTestCase):
         self.assertIn("embed", interaction.response.send_message.call_args.kwargs)
         embed = interaction.response.send_message.call_args.kwargs["embed"]
         self.assertIn("Admin Commands", embed.title)
+
+    async def test_help_allowed_for_guild_admin_perms(self):
+        interaction = _make_interaction(is_owner=False, user_id="222", has_admin_perms=True)
+        await self.commands["admin_help"]["func"](interaction)
+        interaction.response.send_message.assert_called_once()
+        self.assertIn("embed", interaction.response.send_message.call_args.kwargs)
 
     async def test_help_allowed_for_club_admin(self):
         interaction = _make_interaction(is_owner=False, user_id="111")


### PR DESCRIPTION
## Summary

- Replace `_check_guild_owner` with `_check_guild_admin` to grant access to users with `administrator` or `manage_guild` Discord permissions, not just the guild owner
- Add a collision guard in `setup` and `club_create` that returns an error if a club already exists in the target channel

## Ticket

[KT-139](https://www.notion.so/354ef355462380b79a68dbefaf2cbe86)

## Test plan

- [ ] Guild owner can still use all admin commands
- [ ] User with `administrator` permission can use admin commands
- [ ] User with `manage_guild` permission can use admin commands
- [ ] User with no relevant permissions is denied
- [ ] `/setup` in a channel that already has a club returns the collision error
- [ ] `/club_create` in a channel that already has a club returns the collision error
- [ ] `/setup` and `/club_create` succeed in a channel with no existing club