### PR TITLE
feat(commands): add /support, /donate, /bug, and /feedback commands (KT-127)

### DIFF
--- a/cogs/general_commands.py
+++ b/cogs/general_commands.py
@@ -44,8 +44,14 @@ class BugReportModal(discord.ui.Modal, title='Report a Bug'):
             webhook = discord.Webhook.from_url(webhook_url, session=session)
             await webhook.send(embed=embed, thread_name=self.issue_title.value)
 
+        view = discord.ui.View()
+        channel_url = os.getenv("BUG_CHANNEL_URL")
+        if channel_url:
+            view.add_item(discord.ui.Button(label="Go to #bug-reports", url=channel_url))
+
         await interaction.response.send_message(
-            "✅ Thank you! Your submission has been sent directly to the Bookmasters.",
+            "✅ Your bug report has been posted! Feel free to follow up there.",
+            view=view,
             ephemeral=True
         )
 
@@ -85,8 +91,14 @@ class FeedbackModal(discord.ui.Modal, title='Send Feedback'):
             webhook = discord.Webhook.from_url(webhook_url, session=session)
             await webhook.send(embed=embed, thread_name=self.topic.value)
 
+        view = discord.ui.View()
+        channel_url = os.getenv("FEEDBACK_CHANNEL_URL")
+        if channel_url:
+            view.add_item(discord.ui.Button(label="Go to #feedback", url=channel_url))
+
         await interaction.response.send_message(
-            "✅ Thank you! Your submission has been sent directly to the Bookmasters.",
+            "✅ Your feedback has been posted! Feel free to follow up there.",
+            view=view,
             ephemeral=True
         )
 

--- a/cogs/general_commands.py
+++ b/cogs/general_commands.py
@@ -1,15 +1,100 @@
 """
-General commands (help, usage)
+General commands (help, usage, support, donate, bug, feedback)
 """
+import os
+
+import aiohttp
 import discord
-from discord import app_commands
 
 from utils.embeds import create_embed
+
+
+class BugReportModal(discord.ui.Modal, title='Report a Bug'):
+    issue_title = discord.ui.TextInput(
+        label='Issue Title',
+        placeholder='Brief description of the bug',
+        max_length=100
+    )
+    steps = discord.ui.TextInput(
+        label='Steps to Reproduce / Description',
+        style=discord.TextStyle.paragraph,
+        placeholder='Describe the bug and steps to reproduce...',
+        max_length=1000
+    )
+
+    async def on_submit(self, interaction: discord.Interaction):
+        embed = create_embed(
+            title=f"🐛 Bug Report: {self.issue_title.value}",
+            description=self.steps.value,
+            color_key="error"
+        )
+        embed.add_field(
+            name="Reported By",
+            value=f"{interaction.user.name} (ID: {interaction.user.id})",
+            inline=True
+        )
+        embed.add_field(
+            name="Server",
+            value=interaction.guild.name if interaction.guild else "DM",
+            inline=True
+        )
+
+        webhook_url = os.getenv("BUG_WEBHOOK_URL")
+        async with aiohttp.ClientSession() as session:
+            webhook = discord.Webhook.from_url(webhook_url, session=session)
+            await webhook.send(embed=embed, thread_name=self.issue_title.value)
+
+        await interaction.response.send_message(
+            "✅ Thank you! Your submission has been sent directly to the Bookmasters.",
+            ephemeral=True
+        )
+
+
+class FeedbackModal(discord.ui.Modal, title='Send Feedback'):
+    topic = discord.ui.TextInput(
+        label='Topic',
+        placeholder='What is your feedback about?',
+        max_length=100
+    )
+    feedback = discord.ui.TextInput(
+        label='Your Feedback',
+        style=discord.TextStyle.paragraph,
+        placeholder='Share your thoughts...',
+        max_length=1000
+    )
+
+    async def on_submit(self, interaction: discord.Interaction):
+        embed = create_embed(
+            title=f"💬 Feedback: {self.topic.value}",
+            description=self.feedback.value,
+            color_key="info"
+        )
+        embed.add_field(
+            name="Submitted By",
+            value=f"{interaction.user.name} (ID: {interaction.user.id})",
+            inline=True
+        )
+        embed.add_field(
+            name="Server",
+            value=interaction.guild.name if interaction.guild else "DM",
+            inline=True
+        )
+
+        webhook_url = os.getenv("FEEDBACK_WEBHOOK_URL")
+        async with aiohttp.ClientSession() as session:
+            webhook = discord.Webhook.from_url(webhook_url, session=session)
+            await webhook.send(embed=embed, thread_name=self.topic.value)
+
+        await interaction.response.send_message(
+            "✅ Thank you! Your submission has been sent directly to the Bookmasters.",
+            ephemeral=True
+        )
+
 
 def setup_general_commands(bot):
     """
     Setup general commands for the bot
-    
+
     Args:
         bot: The bot instance
     """
@@ -36,7 +121,7 @@ def setup_general_commands(bot):
         embed.set_footer(text=f"Happy reading! 📚")
         await interaction.response.send_message(embed=embed)
         print("Sent help command response.")
-    
+
     @bot.tree.command(name="usage", description="Show all available commands")
     async def usage_command(interaction: discord.Interaction):
         embed = create_embed(
@@ -71,3 +156,33 @@ def setup_general_commands(bot):
         embed.set_footer(text=f"Use / for slash commands, ! for admin commands")
         await interaction.response.send_message(embed=embed)
         print("Sent usage command response.")
+
+    @bot.tree.command(name="support", description="Get support for Kluvs")
+    async def support_command(interaction: discord.Interaction):
+        embed = create_embed(
+            title="🤝 Community Support",
+            description="Need help? Join our community Discord for support, answers, and updates!",
+            color_key="info"
+        )
+        view = discord.ui.View()
+        view.add_item(discord.ui.Button(label="Join Community", url="https://kluvs.com/discord"))
+        await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+
+    @bot.tree.command(name="donate", description="Support the Kluvs project")
+    async def donate_command(interaction: discord.Interaction):
+        embed = create_embed(
+            title="☕ Support Kluvs",
+            description="Kluvs is an indie project built with love. Your support helps keep it alive and growing!\n\nEvery contribution, big or small, means the world to us. Thank you! 🙏",
+            color_key="royal"
+        )
+        view = discord.ui.View()
+        view.add_item(discord.ui.Button(label="Buy Me a Coffee", url="https://buymeacoffee.com/kluvs"))
+        await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+
+    @bot.tree.command(name="bug", description="Report a bug to the Kluvs team")
+    async def bug_command(interaction: discord.Interaction):
+        await interaction.response.send_modal(BugReportModal())
+
+    @bot.tree.command(name="feedback", description="Send feedback to the Kluvs team")
+    async def feedback_command(interaction: discord.Interaction):
+        await interaction.response.send_modal(FeedbackModal())

--- a/cogs/general_commands.py
+++ b/cogs/general_commands.py
@@ -50,7 +50,7 @@ class BugReportModal(discord.ui.Modal, title='Report a Bug'):
             view.add_item(discord.ui.Button(label="Go to #bug-reports", url=channel_url))
 
         await interaction.response.send_message(
-            "✅ Your bug report has been posted! Feel free to follow up there.",
+            "✅ Your bug report has been posted! Feel free to follow up in the Community Server.",
             view=view,
             ephemeral=True
         )
@@ -71,7 +71,7 @@ class FeedbackModal(discord.ui.Modal, title='Send Feedback'):
 
     async def on_submit(self, interaction: discord.Interaction):
         embed = create_embed(
-            title=f"💬 Feedback: {self.topic.value}",
+            title=f"📫 Feedback: {self.topic.value}",
             description=self.feedback.value,
             color_key="info"
         )
@@ -97,7 +97,7 @@ class FeedbackModal(discord.ui.Modal, title='Send Feedback'):
             view.add_item(discord.ui.Button(label="Go to #feedback", url=channel_url))
 
         await interaction.response.send_message(
-            "✅ Your feedback has been posted! Feel free to follow up there.",
+            "✅ Your feedback has been posted! Feel free to follow up  in the Community Server.",
             view=view,
             ephemeral=True
         )

--- a/tests/test_community_commands.py
+++ b/tests/test_community_commands.py
@@ -132,7 +132,42 @@ class TestCommunityCommands(unittest.IsolatedAsyncioTestCase):
         interaction.response.send_message.assert_called_once()
         reply_kwargs = interaction.response.send_message.call_args
         self.assertTrue(reply_kwargs.kwargs.get('ephemeral'))
-        self.assertIn("Thank you", reply_kwargs.args[0])
+        self.assertIn("bug report", reply_kwargs.args[0])
+
+    @patch('cogs.general_commands.aiohttp.ClientSession')
+    @patch('cogs.general_commands.discord.Webhook.from_url')
+    @patch('cogs.general_commands.os.getenv')
+    async def test_bug_modal_reply_includes_channel_button_when_url_set(
+        self, mock_getenv, mock_from_url, mock_session_cls
+    ):
+        mock_getenv.side_effect = lambda key: {
+            "BUG_WEBHOOK_URL": "https://example.com/bug-webhook",
+            "BUG_CHANNEL_URL": "https://discord.com/channels/123/456",
+        }.get(key)
+
+        mock_webhook = AsyncMock()
+        mock_from_url.return_value = mock_webhook
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session_cls.return_value = mock_session
+
+        interaction = AsyncMock()
+        interaction.user.name = "TestUser"
+        interaction.user.id = 123456
+        interaction.guild.name = "Test Server"
+
+        modal = BugReportModal()
+        modal.issue_title = MagicMock()
+        modal.issue_title.value = "Crash on startup"
+        modal.steps = MagicMock()
+        modal.steps.value = "Open the app, it crashes."
+
+        await modal.on_submit(interaction)
+
+        reply_kwargs = interaction.response.send_message.call_args.kwargs
+        self.assertIn('view', reply_kwargs)
 
     # --- FeedbackModal.on_submit ---
 
@@ -173,7 +208,42 @@ class TestCommunityCommands(unittest.IsolatedAsyncioTestCase):
         interaction.response.send_message.assert_called_once()
         reply_kwargs = interaction.response.send_message.call_args
         self.assertTrue(reply_kwargs.kwargs.get('ephemeral'))
-        self.assertIn("Thank you", reply_kwargs.args[0])
+        self.assertIn("feedback", reply_kwargs.args[0])
+
+    @patch('cogs.general_commands.aiohttp.ClientSession')
+    @patch('cogs.general_commands.discord.Webhook.from_url')
+    @patch('cogs.general_commands.os.getenv')
+    async def test_feedback_modal_reply_includes_channel_button_when_url_set(
+        self, mock_getenv, mock_from_url, mock_session_cls
+    ):
+        mock_getenv.side_effect = lambda key: {
+            "FEEDBACK_WEBHOOK_URL": "https://example.com/feedback-webhook",
+            "FEEDBACK_CHANNEL_URL": "https://discord.com/channels/123/789",
+        }.get(key)
+
+        mock_webhook = AsyncMock()
+        mock_from_url.return_value = mock_webhook
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session_cls.return_value = mock_session
+
+        interaction = AsyncMock()
+        interaction.user.name = "TestUser"
+        interaction.user.id = 789012
+        interaction.guild.name = "Test Server"
+
+        modal = FeedbackModal()
+        modal.topic = MagicMock()
+        modal.topic.value = "UI Suggestion"
+        modal.feedback = MagicMock()
+        modal.feedback.value = "Please add a dark mode."
+
+        await modal.on_submit(interaction)
+
+        reply_kwargs = interaction.response.send_message.call_args.kwargs
+        self.assertIn('view', reply_kwargs)
 
 
 if __name__ == '__main__':

--- a/tests/test_community_commands.py
+++ b/tests/test_community_commands.py
@@ -1,0 +1,180 @@
+"""
+Tests for community support & utility commands (support, donate, bug, feedback)
+"""
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from cogs.general_commands import setup_general_commands, BugReportModal, FeedbackModal
+
+
+class TestCommunityCommands(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.bot = MagicMock()
+        self.bot.tree = MagicMock()
+        self.commands = {}
+
+        def mock_command(**kwargs):
+            def decorator(func):
+                self.commands[kwargs.get('name')] = {'func': func, 'kwargs': kwargs}
+                return func
+            return decorator
+
+        self.bot.tree.command = mock_command
+        setup_general_commands(self.bot)
+
+    # --- /support ---
+
+    async def test_support_command_registered(self):
+        self.assertIn('support', self.commands)
+
+    async def test_support_sends_ephemeral_embed_with_view(self):
+        interaction = AsyncMock()
+        await self.commands['support']['func'](interaction)
+
+        interaction.response.send_message.assert_called_once()
+        call_kwargs = interaction.response.send_message.call_args.kwargs
+        self.assertTrue(call_kwargs.get('ephemeral'))
+        self.assertIn('embed', call_kwargs)
+        self.assertIn('view', call_kwargs)
+
+    async def test_support_embed_content(self):
+        interaction = AsyncMock()
+        await self.commands['support']['func'](interaction)
+
+        embed = interaction.response.send_message.call_args.kwargs['embed']
+        self.assertIn("Support", embed.title)
+
+    # --- /donate ---
+
+    async def test_donate_command_registered(self):
+        self.assertIn('donate', self.commands)
+
+    async def test_donate_sends_ephemeral_embed_with_view(self):
+        interaction = AsyncMock()
+        await self.commands['donate']['func'](interaction)
+
+        interaction.response.send_message.assert_called_once()
+        call_kwargs = interaction.response.send_message.call_args.kwargs
+        self.assertTrue(call_kwargs.get('ephemeral'))
+        self.assertIn('embed', call_kwargs)
+        self.assertIn('view', call_kwargs)
+
+    async def test_donate_embed_content(self):
+        interaction = AsyncMock()
+        await self.commands['donate']['func'](interaction)
+
+        embed = interaction.response.send_message.call_args.kwargs['embed']
+        self.assertIn("Kluvs", embed.title)
+
+    # --- /bug ---
+
+    async def test_bug_command_registered(self):
+        self.assertIn('bug', self.commands)
+
+    async def test_bug_sends_modal(self):
+        interaction = AsyncMock()
+        await self.commands['bug']['func'](interaction)
+
+        interaction.response.send_modal.assert_called_once()
+        modal = interaction.response.send_modal.call_args.args[0]
+        self.assertIsInstance(modal, BugReportModal)
+
+    # --- /feedback ---
+
+    async def test_feedback_command_registered(self):
+        self.assertIn('feedback', self.commands)
+
+    async def test_feedback_sends_modal(self):
+        interaction = AsyncMock()
+        await self.commands['feedback']['func'](interaction)
+
+        interaction.response.send_modal.assert_called_once()
+        modal = interaction.response.send_modal.call_args.args[0]
+        self.assertIsInstance(modal, FeedbackModal)
+
+    # --- BugReportModal.on_submit ---
+
+    @patch('cogs.general_commands.aiohttp.ClientSession')
+    @patch('cogs.general_commands.discord.Webhook.from_url')
+    @patch('cogs.general_commands.os.getenv')
+    async def test_bug_modal_on_submit_sends_webhook_and_ephemeral_reply(
+        self, mock_getenv, mock_from_url, mock_session_cls
+    ):
+        mock_getenv.return_value = "https://example.com/bug-webhook"
+
+        mock_webhook = AsyncMock()
+        mock_from_url.return_value = mock_webhook
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session_cls.return_value = mock_session
+
+        interaction = AsyncMock()
+        interaction.user.name = "TestUser"
+        interaction.user.id = 123456
+        interaction.guild.name = "Test Server"
+
+        modal = BugReportModal()
+        modal.issue_title = MagicMock()
+        modal.issue_title.value = "Crash on startup"
+        modal.steps = MagicMock()
+        modal.steps.value = "Open the app, it crashes."
+
+        await modal.on_submit(interaction)
+
+        mock_webhook.send.assert_called_once()
+        send_kwargs = mock_webhook.send.call_args.kwargs
+        self.assertEqual(send_kwargs['thread_name'], "Crash on startup")
+        self.assertIn('embed', send_kwargs)
+
+        interaction.response.send_message.assert_called_once()
+        reply_kwargs = interaction.response.send_message.call_args
+        self.assertTrue(reply_kwargs.kwargs.get('ephemeral'))
+        self.assertIn("Thank you", reply_kwargs.args[0])
+
+    # --- FeedbackModal.on_submit ---
+
+    @patch('cogs.general_commands.aiohttp.ClientSession')
+    @patch('cogs.general_commands.discord.Webhook.from_url')
+    @patch('cogs.general_commands.os.getenv')
+    async def test_feedback_modal_on_submit_sends_webhook_and_ephemeral_reply(
+        self, mock_getenv, mock_from_url, mock_session_cls
+    ):
+        mock_getenv.return_value = "https://example.com/feedback-webhook"
+
+        mock_webhook = AsyncMock()
+        mock_from_url.return_value = mock_webhook
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session_cls.return_value = mock_session
+
+        interaction = AsyncMock()
+        interaction.user.name = "TestUser"
+        interaction.user.id = 789012
+        interaction.guild.name = "Test Server"
+
+        modal = FeedbackModal()
+        modal.topic = MagicMock()
+        modal.topic.value = "UI Suggestion"
+        modal.feedback = MagicMock()
+        modal.feedback.value = "Please add a dark mode."
+
+        await modal.on_submit(interaction)
+
+        mock_webhook.send.assert_called_once()
+        send_kwargs = mock_webhook.send.call_args.kwargs
+        self.assertEqual(send_kwargs['thread_name'], "UI Suggestion")
+        self.assertIn('embed', send_kwargs)
+
+        interaction.response.send_message.assert_called_once()
+        reply_kwargs = interaction.response.send_message.call_args
+        self.assertTrue(reply_kwargs.kwargs.get('ephemeral'))
+        self.assertIn("Thank you", reply_kwargs.args[0])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `/support` and `/donate` as ephemeral slash commands, each returning an embed with a link button
- Adds `/bug` and `/feedback` slash commands that open Discord Modals for user input
- Modal submissions are routed to the Kluvs home server via `BUG_WEBHOOK_URL` and `FEEDBACK_WEBHOOK_URL` webhooks, sending a rich embed with the user's input, Discord ID, username, and server name
- All four interactions are ephemeral to prevent channel clutter

## Ticket

[KT-127](https://www.notion.so/34eef355462380c6adc6ddffb4540a63)

## Test plan

- [ ] `/support` returns an ephemeral embed with a "Join Community" button linking to `https://kluvs.com/discord`
- [ ] `/donate` returns an ephemeral embed with a "Buy Me a Coffee" button linking to `https://buymeacoffee.com/kluvs`
- [ ] `/bug` opens the Bug Report modal with Issue Title + Steps to Reproduce fields
- [ ] `/feedback` opens the Send Feedback modal with Topic + Your Feedback fields
- [ ] Submitting the bug modal sends an embed to the bug forum webhook and replies ephemerally
- [ ] Submitting the feedback modal sends an embed to the feedback webhook and replies ephemerally
- [ ] DevOps: create two webhooks in Server Settings → Integrations, set `BUG_WEBHOOK_URL` and `FEEDBACK_WEBHOOK_URL` in the bot's `.env`