### PR TITLE
chore(setup): improve post-setup embed with next-steps guidance (KT-141)

### DIFF
--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -236,18 +236,34 @@ def setup_admin_commands(bot):
             return
 
         embed = create_embed(
-            title="🎉 You're all set!",
+            title="🎉 Welcome to your book club!",
             description=(
                 f"**{club_name}** has been created in {interaction.channel.mention}.\n\n"
-                "**Available commands:**\n"
-                "`/session` — view the current reading session\n"
-                "`/book` — see the current book\n"
-                "`/duedate` — check the due date\n"
-                "`/discussions` — view scheduled discussions\n"
-                "`/session_create` — start a new session\n"
-                "`/member_add` — add members to the club"
+                "Here's what to do next:"
             ),
             color_key="success",
+            fields=[
+                {
+                    "name": "📖 Owner — pick your first book",
+                    "value": "Use `/session_create` to start your first reading session and choose what the club reads.",
+                    "inline": False,
+                },
+                {
+                    "name": "👥 Everyone else — join the club",
+                    "value": "Type `/join` to get on the roster so you can track progress and participate in discussions.",
+                    "inline": False,
+                },
+                {
+                    "name": "📚 Other useful commands",
+                    "value": (
+                        "`/session` — view the current session\n"
+                        "`/book` — see the current book\n"
+                        "`/duedate` — check the due date\n"
+                        "`/discussions` — view scheduled discussions"
+                    ),
+                    "inline": False,
+                },
+            ],
             footer="Happy reading! 📖"
         )
         await interaction.followup.send(embed=embed)

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -259,7 +259,8 @@ def setup_admin_commands(bot):
                         "`/session` — view the current session\n"
                         "`/book` — see the current book\n"
                         "`/duedate` — check the due date\n"
-                        "`/discussions` — view scheduled discussions"
+                        "`/discussions` — view scheduled discussions\n"
+                        "`/usage` — view all other commands"
                     ),
                     "inline": False,
                 },


### PR DESCRIPTION
## Summary

- Replaced the generic post-`/setup` command list with a structured embed featuring explicit next-steps fields
- Owner is directed to `/session_create` to start the first reading session; everyone else is directed to `/join` to get on the roster
- Fixed a stale reference: the old embed listed `/member_add` for joining — corrected to `/join`

## Ticket

[KT-141 — Post /setup guidance](https://www.notion.so/354ef35546238005bc91e8ebd30389dd)

## Test plan

- [ ] Run `/setup` on a fresh server — verify the success embed shows the two next-steps fields prominently
- [ ] Confirm the "Owner" field points to `/session_create` and the "Members" field points to `/join`
- [ ] Verify the "Other useful commands" field lists the remaining commands correctly
- [ ] Run `make test` — all existing tests should pass (embed tests only assert presence, not content)