### PR TITLE
feat(commands): discussion management with Discord event integration

### DIFF
--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -3,7 +3,7 @@ Admin commands (version, server, club, member, session management)
 """
 import re
 import os
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from typing import Literal
 import discord
 from discord import app_commands
@@ -860,17 +860,21 @@ def setup_admin_commands(bot):
     @app_commands.describe(
         title="Discussion title (e.g. 'Chapters 1-5')",
         date="Discussion date (YYYY-MM-DD)",
-        location="Optional location (e.g. 'Discord', 'Library')",
+        time="Discussion start time in 24h format (HH:MM, e.g. 18:00)",
+        duration="Duration in hours (default: 1)",
+        location="Location (default: Discord)",
         channel="The channel containing the club (defaults to current channel)"
     )
     async def discussion_add(
         interaction: discord.Interaction,
         title: str,
         date: str,
-        location: str = None,
+        time: str,
+        duration: float = 1.0,
+        location: str = "Discord",
         channel: discord.TextChannel = None
     ):
-        """Adds a new discussion to the active reading session."""
+        """Adds a new discussion to the active reading session and creates a Discord scheduled event."""
         await interaction.response.defer()
         target_channel = channel or interaction.channel
         channel_id = str(target_channel.id)
@@ -896,24 +900,59 @@ def setup_admin_commands(bot):
             )
             return
 
+        try:
+            datetime.strptime(time, "%H:%M")
+        except ValueError:
+            await interaction.followup.send(
+                "❌ Time must be in **HH:MM** 24h format (e.g., `18:00`).",
+                ephemeral=True
+            )
+            return
+
+        if duration <= 0:
+            await interaction.followup.send(
+                "❌ Duration must be greater than 0.",
+                ephemeral=True
+            )
+            return
+
         session_id = club_data["active_session"]["id"]
-        new_discussion = {"title": title.strip(), "date": date.strip()}
-        if location and location.strip():
-            new_discussion["location"] = location.strip()
+        resolved_location = location.strip() if location and location.strip() else "Discord"
+        new_discussion = {"title": title.strip(), "date": date.strip(), "location": resolved_location}
 
         try:
             bot.api.update_session(session_id, {"discussions": [new_discussion]})
-            description = f"Added **{title}** on {date}"
-            if location:
-                description += f" at {location}"
-            embed = create_embed(
-                title="✅ Discussion Added",
-                description=description + ".",
-                color_key="success"
-            )
-            await interaction.followup.send(embed=embed)
         except APIError as e:
             await interaction.followup.send(f"❌ Failed to add discussion: {e}")
+            return
+
+        # Build timezone-aware datetimes for the Discord event
+        start_dt = datetime.strptime(f"{date} {time}", "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc)
+        end_dt = start_dt + timedelta(hours=duration)
+
+        event_warning = ""
+        try:
+            await interaction.guild.create_scheduled_event(
+                name=title.strip(),
+                start_time=start_dt,
+                end_time=end_dt,
+                entity_type=discord.EntityType.external,
+                privacy_level=discord.PrivacyLevel.guild_only,
+                location=resolved_location,
+                description=f"Book club discussion: {title.strip()}",
+            )
+        except discord.Forbidden:
+            event_warning = "\n⚠️ Discussion saved, but couldn't create a Discord event — the bot is missing **Manage Events** permission."
+        except discord.HTTPException as e:
+            event_warning = f"\n⚠️ Discussion saved, but Discord event creation failed: {e}"
+
+        description = f"Added **{title}** on {date} at {time} ({resolved_location})"
+        embed = create_embed(
+            title="✅ Discussion Added",
+            description=description + "." + event_warning,
+            color_key="success"
+        )
+        await interaction.followup.send(embed=embed)
 
     @bot.tree.command(name="discussion_update", description="Update an existing discussion in the active session")
     @app_commands.autocomplete(discussion_id=discussion_autocomplete)

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -12,6 +12,27 @@ from utils.embeds import create_embed
 from api.bookclub_api import APIError, ResourceNotFoundError
 
 
+async def discussion_autocomplete(interaction: discord.Interaction, current: str) -> list[app_commands.Choice[str]]:
+    """Autocomplete discussion IDs from the active session for update/delete commands."""
+    try:
+        channel_id = str(interaction.channel_id)
+        guild_id = str(interaction.guild_id)
+        club_data = interaction.client.api.find_club_in_channel(channel_id, guild_id)
+        if not club_data or not club_data.get("active_session"):
+            return []
+        session_id = club_data["active_session"]["id"]
+        session = interaction.client.api.get_session(session_id)
+        discussions = session.get("discussions", [])
+        choices = []
+        for d in discussions:
+            label = f"{d.get('title', 'Untitled')} — {d.get('date', '')}"
+            if not current or current.lower() in label.lower():
+                choices.append(app_commands.Choice(name=label[:100], value=d["id"]))
+        return choices[:25]
+    except Exception:
+        return []
+
+
 async def book_autocomplete(interaction: discord.Interaction, current: str) -> list[app_commands.Choice[str]]:
     if len(current) < 2:
         return []
@@ -191,6 +212,15 @@ def setup_admin_commands(bot):
                         "`/session_create` — Create a reading session\n"
                         "`/session_update` — Update session\n"
                         "`/session_delete` — Delete the active session"
+                    ),
+                    "inline": False
+                },
+                {
+                    "name": "💬 Discussion Management",
+                    "value": (
+                        "`/discussion_add` — Add a discussion to the active session\n"
+                        "`/discussion_update` — Update an existing discussion\n"
+                        "`/discussion_delete` — Delete a discussion"
                     ),
                     "inline": False
                 },
@@ -823,3 +853,199 @@ def setup_admin_commands(bot):
             await interaction.followup.send(embed=embed)
         except APIError as e:
             await interaction.followup.send(f"❌ Failed to delete session: {e}")
+
+    # ── Discussion commands (club admin+) ─────────────────────────────────────
+
+    @bot.tree.command(name="discussion_add", description="Add a discussion to the active session")
+    @app_commands.describe(
+        title="Discussion title (e.g. 'Chapters 1-5')",
+        date="Discussion date (YYYY-MM-DD)",
+        location="Optional location (e.g. 'Discord', 'Library')",
+        channel="The channel containing the club (defaults to current channel)"
+    )
+    async def discussion_add(
+        interaction: discord.Interaction,
+        title: str,
+        date: str,
+        location: str = None,
+        channel: discord.TextChannel = None
+    ):
+        """Adds a new discussion to the active reading session."""
+        await interaction.response.defer()
+        target_channel = channel or interaction.channel
+        channel_id = str(target_channel.id)
+        guild_id = str(interaction.guild_id)
+
+        club_data = bot.api.find_club_in_channel(channel_id, guild_id)
+        if not _can_manage_clubs(interaction, club_data):
+            await interaction.followup.send(
+                "❌ You need to be a club admin or owner to use this command.",
+                ephemeral=True
+            )
+            return
+        if not club_data or not club_data.get("active_session"):
+            await interaction.followup.send("❌ No active session found in that channel.")
+            return
+
+        try:
+            datetime.strptime(date, "%Y-%m-%d")
+        except ValueError:
+            await interaction.followup.send(
+                "❌ Date must be in **YYYY-MM-DD** format (e.g., `2026-05-15`).",
+                ephemeral=True
+            )
+            return
+
+        session_id = club_data["active_session"]["id"]
+        new_discussion = {"title": title.strip(), "date": date.strip()}
+        if location and location.strip():
+            new_discussion["location"] = location.strip()
+
+        try:
+            bot.api.update_session(session_id, {"discussions": [new_discussion]})
+            description = f"Added **{title}** on {date}"
+            if location:
+                description += f" at {location}"
+            embed = create_embed(
+                title="✅ Discussion Added",
+                description=description + ".",
+                color_key="success"
+            )
+            await interaction.followup.send(embed=embed)
+        except APIError as e:
+            await interaction.followup.send(f"❌ Failed to add discussion: {e}")
+
+    @bot.tree.command(name="discussion_update", description="Update an existing discussion in the active session")
+    @app_commands.autocomplete(discussion_id=discussion_autocomplete)
+    @app_commands.describe(
+        discussion_id="The discussion to update (select from autocomplete)",
+        title="New title",
+        date="New date (YYYY-MM-DD)",
+        location="New location",
+        channel="The channel containing the club (defaults to current channel)"
+    )
+    async def discussion_update_command(
+        interaction: discord.Interaction,
+        discussion_id: str,
+        title: str = None,
+        date: str = None,
+        location: str = None,
+        channel: discord.TextChannel = None
+    ):
+        """Updates an existing discussion in the active reading session."""
+        await interaction.response.defer()
+        target_channel = channel or interaction.channel
+        channel_id = str(target_channel.id)
+        guild_id = str(interaction.guild_id)
+
+        club_data = bot.api.find_club_in_channel(channel_id, guild_id)
+        if not _can_manage_clubs(interaction, club_data):
+            await interaction.followup.send(
+                "❌ You need to be a club admin or owner to use this command.",
+                ephemeral=True
+            )
+            return
+        if not club_data or not club_data.get("active_session"):
+            await interaction.followup.send("❌ No active session found in that channel.")
+            return
+
+        if not any([title, date, location]):
+            await interaction.followup.send(
+                "❌ Provide at least one field to update (title, date, or location)."
+            )
+            return
+
+        if date:
+            try:
+                datetime.strptime(date, "%Y-%m-%d")
+            except ValueError:
+                await interaction.followup.send(
+                    "❌ Date must be in **YYYY-MM-DD** format (e.g., `2026-05-15`).",
+                    ephemeral=True
+                )
+                return
+
+        session_id = club_data["active_session"]["id"]
+        try:
+            session = bot.api.get_session(session_id)
+        except APIError as e:
+            await interaction.followup.send(f"❌ Failed to retrieve session: {e}")
+            return
+
+        discussions = session.get("discussions", [])
+        current = next((d for d in discussions if d["id"] == discussion_id), None)
+        if not current:
+            await interaction.followup.send("❌ Discussion not found in the active session.")
+            return
+
+        updated = {
+            "id": discussion_id,
+            "title": title.strip() if title else current["title"],
+            "date": date.strip() if date else current["date"],
+        }
+        resolved_location = location.strip() if location else current.get("location")
+        if resolved_location:
+            updated["location"] = resolved_location
+
+        try:
+            bot.api.update_session(session_id, {"discussions": [updated]})
+            description = f"Updated **{updated['title']}** on {updated['date']}"
+            if updated.get("location"):
+                description += f" at {updated['location']}"
+            embed = create_embed(
+                title="✅ Discussion Updated",
+                description=description + ".",
+                color_key="success"
+            )
+            await interaction.followup.send(embed=embed)
+        except APIError as e:
+            await interaction.followup.send(f"❌ Failed to update discussion: {e}")
+
+    @bot.tree.command(name="discussion_delete", description="Delete a discussion from the active session")
+    @app_commands.autocomplete(discussion_id=discussion_autocomplete)
+    @app_commands.describe(
+        discussion_id="The discussion to delete (select from autocomplete)",
+        channel="The channel containing the club (defaults to current channel)"
+    )
+    async def discussion_delete_command(
+        interaction: discord.Interaction,
+        discussion_id: str,
+        channel: discord.TextChannel = None
+    ):
+        """Deletes a discussion from the active reading session."""
+        await interaction.response.defer()
+        target_channel = channel or interaction.channel
+        channel_id = str(target_channel.id)
+        guild_id = str(interaction.guild_id)
+
+        club_data = bot.api.find_club_in_channel(channel_id, guild_id)
+        if not _can_manage_clubs(interaction, club_data):
+            await interaction.followup.send(
+                "❌ You need to be a club admin or owner to use this command.",
+                ephemeral=True
+            )
+            return
+        if not club_data or not club_data.get("active_session"):
+            await interaction.followup.send("❌ No active session found in that channel.")
+            return
+
+        confirmed = await _confirm(
+            interaction,
+            "⚠️ This will permanently delete the selected discussion. "
+            "Click **Confirm** to proceed or **Cancel** to abort."
+        )
+        if not confirmed:
+            await interaction.followup.send("Action cancelled.")
+            return
+
+        session_id = club_data["active_session"]["id"]
+        try:
+            bot.api.update_session(session_id, {"discussion_ids_to_delete": [discussion_id]})
+            embed = create_embed(
+                title="✅ Discussion Deleted",
+                description="The discussion has been removed from the session.",
+                color_key="success"
+            )
+            await interaction.followup.send(embed=embed)
+        except APIError as e:
+            await interaction.followup.send(f"❌ Failed to delete discussion: {e}")

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -11,6 +11,9 @@ from discord import app_commands
 from utils.embeds import create_embed
 from api.bookclub_api import APIError, ResourceNotFoundError
 
+# Marker embedded in Discord event descriptions so discussion_sync can match them.
+_DISC_ID_RE = re.compile(r"discussion_id:(\S+)")
+
 
 async def discussion_autocomplete(interaction: discord.Interaction, current: str) -> list[app_commands.Choice[str]]:
     """Autocomplete discussion IDs from the active session for update/delete commands."""
@@ -218,9 +221,10 @@ def setup_admin_commands(bot):
                 {
                     "name": "💬 Discussion Management",
                     "value": (
-                        "`/discussion_add` — Add a discussion to the active session\n"
+                        "`/discussion_add` — Add a discussion and create a Discord event\n"
                         "`/discussion_update` — Update an existing discussion\n"
-                        "`/discussion_delete` — Delete a discussion"
+                        "`/discussion_delete` — Delete a discussion\n"
+                        "`/discussion_sync` — Create Discord events for all discussions missing one"
                     ),
                     "inline": False
                 },
@@ -926,9 +930,27 @@ def setup_admin_commands(bot):
             await interaction.followup.send(f"❌ Failed to add discussion: {e}")
             return
 
+        # Retrieve the server-assigned discussion ID so we can embed it in the event.
+        disc_id = None
+        try:
+            session = bot.api.get_session(session_id)
+            match = next(
+                (d for d in session.get("discussions", [])
+                 if d.get("title") == new_discussion["title"] and d.get("date") == new_discussion["date"]),
+                None
+            )
+            if match:
+                disc_id = match["id"]
+        except APIError:
+            pass  # Non-fatal — event will be created without an embedded ID
+
         # Build timezone-aware datetimes for the Discord event
         start_dt = datetime.strptime(f"{date} {time}", "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc)
         end_dt = start_dt + timedelta(hours=duration)
+
+        event_description = f"Book club discussion: {title.strip()}"
+        if disc_id:
+            event_description += f"\ndiscussion_id:{disc_id}"
 
         event_warning = ""
         try:
@@ -939,7 +961,7 @@ def setup_admin_commands(bot):
                 entity_type=discord.EntityType.external,
                 privacy_level=discord.PrivacyLevel.guild_only,
                 location=resolved_location,
-                description=f"Book club discussion: {title.strip()}",
+                description=event_description,
             )
         except discord.Forbidden:
             event_warning = "\n⚠️ Discussion saved, but couldn't create a Discord event — the bot is missing **Manage Events** permission."
@@ -1088,3 +1110,129 @@ def setup_admin_commands(bot):
             await interaction.followup.send(embed=embed)
         except APIError as e:
             await interaction.followup.send(f"❌ Failed to delete discussion: {e}")
+
+    @bot.tree.command(name="discussion_sync", description="Create Discord events for any discussions that don't have one")
+    @app_commands.describe(
+        default_time="Start time for created events in HH:MM 24h format (default: 18:00)",
+        default_duration="Duration in hours for created events (default: 1.0)",
+        channel="The channel containing the club (defaults to current channel)"
+    )
+    async def discussion_sync(
+        interaction: discord.Interaction,
+        default_time: str = "18:00",
+        default_duration: float = 1.0,
+        channel: discord.TextChannel = None
+    ):
+        """Ensures every discussion in the active session has a corresponding Discord scheduled event."""
+        await interaction.response.defer()
+        target_channel = channel or interaction.channel
+        channel_id = str(target_channel.id)
+        guild_id = str(interaction.guild_id)
+
+        club_data = bot.api.find_club_in_channel(channel_id, guild_id)
+        if not _can_manage_clubs(interaction, club_data):
+            await interaction.followup.send(
+                "❌ You need to be a club admin or owner to use this command.",
+                ephemeral=True
+            )
+            return
+        if not club_data or not club_data.get("active_session"):
+            await interaction.followup.send("❌ No active session found in that channel.")
+            return
+
+        try:
+            datetime.strptime(default_time, "%H:%M")
+        except ValueError:
+            await interaction.followup.send(
+                "❌ default_time must be in **HH:MM** 24h format (e.g., `18:00`).",
+                ephemeral=True
+            )
+            return
+
+        if default_duration <= 0:
+            await interaction.followup.send(
+                "❌ default_duration must be greater than 0.",
+                ephemeral=True
+            )
+            return
+
+        session_id = club_data["active_session"]["id"]
+        try:
+            session = bot.api.get_session(session_id)
+        except APIError as e:
+            await interaction.followup.send(f"❌ Failed to retrieve session: {e}")
+            return
+
+        discussions = session.get("discussions", [])
+        if not discussions:
+            await interaction.followup.send("ℹ️ No discussions found in the active session.")
+            return
+
+        # Build the set of discussion IDs already covered by an existing guild event.
+        try:
+            existing_events = await interaction.guild.fetch_scheduled_events()
+        except discord.Forbidden:
+            await interaction.followup.send(
+                "❌ Couldn't fetch guild events — the bot is missing **Manage Events** permission."
+            )
+            return
+
+        covered_ids = set()
+        for event in existing_events:
+            m = _DISC_ID_RE.search(event.description or "")
+            if m:
+                covered_ids.add(m.group(1))
+
+        created, skipped, failed = [], [], []
+
+        for disc in discussions:
+            disc_id = disc.get("id")
+            disc_title = disc.get("title", "Untitled")
+
+            if disc_id in covered_ids:
+                skipped.append(disc_title)
+                continue
+
+            # Parse the date; skip gracefully if it's not in the expected format.
+            raw_date = disc.get("date", "")
+            try:
+                start_dt = datetime.strptime(f"{raw_date} {default_time}", "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc)
+            except ValueError:
+                failed.append(f"{disc_title} (unparseable date: {raw_date!r})")
+                continue
+
+            end_dt = start_dt + timedelta(hours=default_duration)
+            event_description = f"Book club discussion: {disc_title}"
+            if disc_id:
+                event_description += f"\ndiscussion_id:{disc_id}"
+
+            try:
+                await interaction.guild.create_scheduled_event(
+                    name=disc_title,
+                    start_time=start_dt,
+                    end_time=end_dt,
+                    entity_type=discord.EntityType.external,
+                    privacy_level=discord.PrivacyLevel.guild_only,
+                    location=disc.get("location") or "Discord",
+                    description=event_description,
+                )
+                created.append(disc_title)
+            except (discord.Forbidden, discord.HTTPException) as e:
+                failed.append(f"{disc_title} ({e})")
+
+        lines = []
+        if created:
+            lines.append(f"✅ Created {len(created)} event(s): {', '.join(f'**{t}**' for t in created)}")
+        if skipped:
+            lines.append(f"⏭️ Already had events: {', '.join(f'**{t}**' for t in skipped)}")
+        if failed:
+            lines.append(f"⚠️ Failed to create: {', '.join(failed)}")
+        if not lines:
+            lines.append("ℹ️ Nothing to sync.")
+
+        embed = create_embed(
+            title="🔄 Discussion Sync Complete",
+            description="\n".join(lines),
+            color_key="info"
+        )
+        await interaction.followup.send(embed=embed)

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -1073,5 +1073,291 @@ class TestBookAutocompleteAdvanced(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(choices[0].name, "Book")
 
 
+class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.bot, self.commands = _make_bot()
+        self.club = _club_with_admin("111")
+        self.session_with_discussions = {
+            "id": "sess-1",
+            "discussions": [
+                {"id": "disc-1", "title": "Chapters 1-5", "date": "2026-06-01", "location": "Discord"},
+                {"id": "disc-2", "title": "Chapters 6-10", "date": "2026-06-15"},
+            ]
+        }
+
+    # ── discussion_add ────────────────────────────────────────────────────────
+
+    async def test_discussion_add_success(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_session.return_value = {"success": True}
+        await self.commands["discussion_add"]["func"](
+            interaction, title="Chapters 1-5", date="2026-06-01", location="Discord"
+        )
+        self.bot.api.update_session.assert_called_once_with(
+            "sess-1", {"discussions": [{"title": "Chapters 1-5", "date": "2026-06-01", "location": "Discord"}]}
+        )
+        self.assertIn("embed", interaction.followup.send.call_args.kwargs)
+
+    async def test_discussion_add_no_location(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_session.return_value = {"success": True}
+        await self.commands["discussion_add"]["func"](
+            interaction, title="Intro", date="2026-06-01"
+        )
+        self.bot.api.update_session.assert_called_once_with(
+            "sess-1", {"discussions": [{"title": "Intro", "date": "2026-06-01"}]}
+        )
+
+    async def test_discussion_add_invalid_date(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        await self.commands["discussion_add"]["func"](
+            interaction, title="Intro", date="06/01/2026"
+        )
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.bot.api.update_session.assert_not_called()
+
+    async def test_discussion_add_permission_denied(self):
+        interaction = _make_interaction(user_id="999", is_owner=False)
+        self.bot.api.find_club_in_channel.return_value = self.club
+        await self.commands["discussion_add"]["func"](
+            interaction, title="Intro", date="2026-06-01"
+        )
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.bot.api.update_session.assert_not_called()
+
+    async def test_discussion_add_no_session(self):
+        interaction = _make_interaction(user_id="111")
+        club_no_session = dict(self.club)
+        club_no_session["active_session"] = None
+        self.bot.api.find_club_in_channel.return_value = club_no_session
+        await self.commands["discussion_add"]["func"](
+            interaction, title="Intro", date="2026-06-01"
+        )
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.bot.api.update_session.assert_not_called()
+
+    async def test_discussion_add_api_error(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_session.side_effect = APIError("failed")
+        await self.commands["discussion_add"]["func"](
+            interaction, title="Intro", date="2026-06-01"
+        )
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+
+    # ── discussion_update ─────────────────────────────────────────────────────
+
+    async def test_discussion_update_success(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_session.return_value = self.session_with_discussions
+        self.bot.api.update_session.return_value = {"success": True}
+        await self.commands["discussion_update"]["func"](
+            interaction, discussion_id="disc-1", title="Updated Title"
+        )
+        self.bot.api.update_session.assert_called_once_with(
+            "sess-1",
+            {"discussions": [{"id": "disc-1", "title": "Updated Title", "date": "2026-06-01", "location": "Discord"}]}
+        )
+        self.assertIn("embed", interaction.followup.send.call_args.kwargs)
+
+    async def test_discussion_update_no_args(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        await self.commands["discussion_update"]["func"](
+            interaction, discussion_id="disc-1"
+        )
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.bot.api.update_session.assert_not_called()
+
+    async def test_discussion_update_invalid_date(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        await self.commands["discussion_update"]["func"](
+            interaction, discussion_id="disc-1", date="01-06-2026"
+        )
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.bot.api.update_session.assert_not_called()
+
+    async def test_discussion_update_not_found(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_session.return_value = self.session_with_discussions
+        await self.commands["discussion_update"]["func"](
+            interaction, discussion_id="disc-999", title="New Title"
+        )
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.bot.api.update_session.assert_not_called()
+
+    async def test_discussion_update_permission_denied(self):
+        interaction = _make_interaction(user_id="999", is_owner=False)
+        self.bot.api.find_club_in_channel.return_value = self.club
+        await self.commands["discussion_update"]["func"](
+            interaction, discussion_id="disc-1", title="New"
+        )
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.bot.api.update_session.assert_not_called()
+
+    async def test_discussion_update_no_session(self):
+        interaction = _make_interaction(user_id="111")
+        club_no_session = dict(self.club)
+        club_no_session["active_session"] = None
+        self.bot.api.find_club_in_channel.return_value = club_no_session
+        await self.commands["discussion_update"]["func"](
+            interaction, discussion_id="disc-1", title="New"
+        )
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.bot.api.update_session.assert_not_called()
+
+    async def test_discussion_update_api_error_on_get(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_session.side_effect = APIError("get failed")
+        await self.commands["discussion_update"]["func"](
+            interaction, discussion_id="disc-1", title="New"
+        )
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.bot.api.update_session.assert_not_called()
+
+    async def test_discussion_update_api_error_on_update(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_session.return_value = self.session_with_discussions
+        self.bot.api.update_session.side_effect = APIError("update failed")
+        await self.commands["discussion_update"]["func"](
+            interaction, discussion_id="disc-1", title="New"
+        )
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+
+    # ── discussion_delete ─────────────────────────────────────────────────────
+
+    async def test_discussion_delete_success(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_session.return_value = {"success": True}
+        with patch.object(discord.ui.View, "wait", _auto_confirm()):
+            await self.commands["discussion_delete"]["func"](interaction, discussion_id="disc-1")
+        self.bot.api.update_session.assert_called_once_with(
+            "sess-1", {"discussion_ids_to_delete": ["disc-1"]}
+        )
+        self.assertIn("embed", interaction.followup.send.call_args.kwargs)
+
+    async def test_discussion_delete_cancelled(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        with patch.object(discord.ui.View, "wait", _no_confirm()):
+            await self.commands["discussion_delete"]["func"](interaction, discussion_id="disc-1")
+        self.bot.api.update_session.assert_not_called()
+        self.assertIn("cancelled", interaction.followup.send.call_args.args[0])
+
+    async def test_discussion_delete_permission_denied(self):
+        interaction = _make_interaction(user_id="999", is_owner=False)
+        self.bot.api.find_club_in_channel.return_value = self.club
+        await self.commands["discussion_delete"]["func"](interaction, discussion_id="disc-1")
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.bot.api.update_session.assert_not_called()
+
+    async def test_discussion_delete_no_session(self):
+        interaction = _make_interaction(user_id="111")
+        club_no_session = dict(self.club)
+        club_no_session["active_session"] = None
+        self.bot.api.find_club_in_channel.return_value = club_no_session
+        await self.commands["discussion_delete"]["func"](interaction, discussion_id="disc-1")
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.bot.api.update_session.assert_not_called()
+
+    async def test_discussion_delete_api_error(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_session.side_effect = APIError("delete failed")
+        with patch.object(discord.ui.View, "wait", _auto_confirm()):
+            await self.commands["discussion_delete"]["func"](interaction, discussion_id="disc-1")
+        self.assertIn("❌", interaction.followup.send.call_args_list[-1].args[0])
+
+
+class TestDiscussionAutocomplete(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_choices_for_active_session(self):
+        interaction = AsyncMock()
+        interaction.channel_id = 999
+        interaction.guild_id = 888
+        interaction.client = MagicMock()
+        interaction.client.api.find_club_in_channel.return_value = {
+            "id": "club-1",
+            "active_session": {"id": "sess-1"}
+        }
+        interaction.client.api.get_session.return_value = {
+            "discussions": [
+                {"id": "disc-1", "title": "Chapters 1-5", "date": "2026-06-01"},
+                {"id": "disc-2", "title": "Chapters 6-10", "date": "2026-06-15"},
+            ]
+        }
+
+        from cogs.admin_commands import discussion_autocomplete
+        choices = await discussion_autocomplete(interaction, "")
+        self.assertEqual(len(choices), 2)
+        self.assertEqual(choices[0].value, "disc-1")
+        self.assertEqual(choices[1].value, "disc-2")
+
+    async def test_filters_by_current_text(self):
+        interaction = AsyncMock()
+        interaction.channel_id = 999
+        interaction.guild_id = 888
+        interaction.client = MagicMock()
+        interaction.client.api.find_club_in_channel.return_value = {
+            "id": "club-1",
+            "active_session": {"id": "sess-1"}
+        }
+        interaction.client.api.get_session.return_value = {
+            "discussions": [
+                {"id": "disc-1", "title": "Chapters 1-5", "date": "2026-06-01"},
+                {"id": "disc-2", "title": "Final meeting", "date": "2026-07-01"},
+            ]
+        }
+
+        from cogs.admin_commands import discussion_autocomplete
+        choices = await discussion_autocomplete(interaction, "final")
+        self.assertEqual(len(choices), 1)
+        self.assertEqual(choices[0].value, "disc-2")
+
+    async def test_returns_empty_when_no_club(self):
+        interaction = AsyncMock()
+        interaction.channel_id = 999
+        interaction.guild_id = 888
+        interaction.client = MagicMock()
+        interaction.client.api.find_club_in_channel.return_value = None
+
+        from cogs.admin_commands import discussion_autocomplete
+        choices = await discussion_autocomplete(interaction, "")
+        self.assertEqual(choices, [])
+
+    async def test_returns_empty_when_no_active_session(self):
+        interaction = AsyncMock()
+        interaction.channel_id = 999
+        interaction.guild_id = 888
+        interaction.client = MagicMock()
+        interaction.client.api.find_club_in_channel.return_value = {
+            "id": "club-1",
+            "active_session": None
+        }
+
+        from cogs.admin_commands import discussion_autocomplete
+        choices = await discussion_autocomplete(interaction, "")
+        self.assertEqual(choices, [])
+
+    async def test_returns_empty_on_exception(self):
+        interaction = AsyncMock()
+        interaction.channel_id = 999
+        interaction.guild_id = 888
+        interaction.client = MagicMock()
+        interaction.client.api.find_club_in_channel.side_effect = Exception("API down")
+
+        from cogs.admin_commands import discussion_autocomplete
+        choices = await discussion_autocomplete(interaction, "")
+        self.assertEqual(choices, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -1091,6 +1091,9 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.update_session.return_value = {"success": True}
+        self.bot.api.get_session.return_value = {
+            "discussions": [{"id": "disc-new", "title": "Chapters 1-5", "date": "2026-06-01", "location": "Discord"}]
+        }
         interaction.guild.create_scheduled_event = AsyncMock()
         await self.commands["discussion_add"]["func"](
             interaction, title="Chapters 1-5", date="2026-06-01", time="18:00"
@@ -1099,12 +1102,43 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             "sess-1", {"discussions": [{"title": "Chapters 1-5", "date": "2026-06-01", "location": "Discord"}]}
         )
         interaction.guild.create_scheduled_event.assert_called_once()
+        call_kwargs = interaction.guild.create_scheduled_event.call_args.kwargs
+        self.assertIn("discussion_id:disc-new", call_kwargs["description"])
         self.assertIn("embed", interaction.followup.send.call_args.kwargs)
+
+    async def test_discussion_add_embeds_id_in_event_description(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_session.return_value = {"success": True}
+        self.bot.api.get_session.return_value = {
+            "discussions": [{"id": "disc-abc", "title": "Intro", "date": "2026-06-01"}]
+        }
+        interaction.guild.create_scheduled_event = AsyncMock()
+        await self.commands["discussion_add"]["func"](
+            interaction, title="Intro", date="2026-06-01", time="18:00"
+        )
+        desc = interaction.guild.create_scheduled_event.call_args.kwargs["description"]
+        self.assertIn("discussion_id:disc-abc", desc)
+
+    async def test_discussion_add_event_created_without_id_on_get_session_failure(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_session.return_value = {"success": True}
+        self.bot.api.get_session.side_effect = APIError("unavailable")
+        interaction.guild.create_scheduled_event = AsyncMock()
+        await self.commands["discussion_add"]["func"](
+            interaction, title="Intro", date="2026-06-01", time="18:00"
+        )
+        # Event should still be created, just without an embedded ID
+        interaction.guild.create_scheduled_event.assert_called_once()
+        desc = interaction.guild.create_scheduled_event.call_args.kwargs["description"]
+        self.assertNotIn("discussion_id:", desc)
 
     async def test_discussion_add_custom_location(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.update_session.return_value = {"success": True}
+        self.bot.api.get_session.return_value = {"discussions": []}
         interaction.guild.create_scheduled_event = AsyncMock()
         await self.commands["discussion_add"]["func"](
             interaction, title="Intro", date="2026-06-01", time="19:00", location="Library"
@@ -1119,6 +1153,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.update_session.return_value = {"success": True}
+        self.bot.api.get_session.return_value = {"discussions": []}
         interaction.guild.create_scheduled_event = AsyncMock()
         await self.commands["discussion_add"]["func"](
             interaction, title="Intro", date="2026-06-01", time="18:00"
@@ -1188,6 +1223,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.update_session.return_value = {"success": True}
+        self.bot.api.get_session.return_value = {"discussions": []}
         interaction.guild.create_scheduled_event = AsyncMock(
             side_effect=discord.Forbidden(MagicMock(), "Missing Permissions")
         )
@@ -1202,6 +1238,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.update_session.return_value = {"success": True}
+        self.bot.api.get_session.return_value = {"discussions": []}
         interaction.guild.create_scheduled_event = AsyncMock(
             side_effect=discord.HTTPException(MagicMock(), "Bad Request")
         )
@@ -1340,6 +1377,133 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
         with patch.object(discord.ui.View, "wait", _auto_confirm()):
             await self.commands["discussion_delete"]["func"](interaction, discussion_id="disc-1")
         self.assertIn("❌", interaction.followup.send.call_args_list[-1].args[0])
+
+
+class TestDiscussionSync(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.bot, self.commands = _make_bot()
+        self.club = _club_with_admin("111")
+        self.discussions = [
+            {"id": "disc-1", "title": "Chapters 1-5", "date": "2026-06-01", "location": "Discord"},
+            {"id": "disc-2", "title": "Chapters 6-10", "date": "2026-06-15"},
+        ]
+
+    def _make_event(self, description=""):
+        event = MagicMock()
+        event.description = description
+        return event
+
+    async def test_sync_creates_missing_events(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_session.return_value = {"discussions": self.discussions}
+        interaction.guild.fetch_scheduled_events = AsyncMock(return_value=[])
+        interaction.guild.create_scheduled_event = AsyncMock()
+        await self.commands["discussion_sync"]["func"](interaction)
+        self.assertEqual(interaction.guild.create_scheduled_event.call_count, 2)
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        self.assertIn("Created 2", embed.description)
+
+    async def test_sync_skips_already_covered_discussions(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_session.return_value = {"discussions": self.discussions}
+        existing = self._make_event("Book club discussion: Chapters 1-5\ndiscussion_id:disc-1")
+        interaction.guild.fetch_scheduled_events = AsyncMock(return_value=[existing])
+        interaction.guild.create_scheduled_event = AsyncMock()
+        await self.commands["discussion_sync"]["func"](interaction)
+        self.assertEqual(interaction.guild.create_scheduled_event.call_count, 1)
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        self.assertIn("Created 1", embed.description)
+        self.assertIn("Already had events", embed.description)
+
+    async def test_sync_all_already_covered(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_session.return_value = {"discussions": self.discussions}
+        existing = [
+            self._make_event("discussion_id:disc-1"),
+            self._make_event("discussion_id:disc-2"),
+        ]
+        interaction.guild.fetch_scheduled_events = AsyncMock(return_value=existing)
+        interaction.guild.create_scheduled_event = AsyncMock()
+        await self.commands["discussion_sync"]["func"](interaction)
+        interaction.guild.create_scheduled_event.assert_not_called()
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        self.assertIn("Already had events", embed.description)
+
+    async def test_sync_embeds_discussion_id_in_new_events(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_session.return_value = {"discussions": [self.discussions[0]]}
+        interaction.guild.fetch_scheduled_events = AsyncMock(return_value=[])
+        interaction.guild.create_scheduled_event = AsyncMock()
+        await self.commands["discussion_sync"]["func"](interaction)
+        desc = interaction.guild.create_scheduled_event.call_args.kwargs["description"]
+        self.assertIn("discussion_id:disc-1", desc)
+
+    async def test_sync_skips_discussions_with_unparseable_date(self):
+        interaction = _make_interaction(user_id="111")
+        bad_discussion = {"id": "disc-bad", "title": "Bad Date", "date": "sometime in June"}
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_session.return_value = {"discussions": [bad_discussion]}
+        interaction.guild.fetch_scheduled_events = AsyncMock(return_value=[])
+        interaction.guild.create_scheduled_event = AsyncMock()
+        await self.commands["discussion_sync"]["func"](interaction)
+        interaction.guild.create_scheduled_event.assert_not_called()
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        self.assertIn("Failed to create", embed.description)
+
+    async def test_sync_no_discussions(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_session.return_value = {"discussions": []}
+        await self.commands["discussion_sync"]["func"](interaction)
+        self.assertIn("No discussions", interaction.followup.send.call_args.args[0])
+
+    async def test_sync_permission_denied(self):
+        interaction = _make_interaction(user_id="999", is_owner=False)
+        self.bot.api.find_club_in_channel.return_value = self.club
+        await self.commands["discussion_sync"]["func"](interaction)
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+
+    async def test_sync_no_session(self):
+        interaction = _make_interaction(user_id="111")
+        club_no_session = dict(self.club)
+        club_no_session["active_session"] = None
+        self.bot.api.find_club_in_channel.return_value = club_no_session
+        await self.commands["discussion_sync"]["func"](interaction)
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+
+    async def test_sync_invalid_default_time(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        await self.commands["discussion_sync"]["func"](interaction, default_time="6pm")
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+
+    async def test_sync_invalid_default_duration(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        await self.commands["discussion_sync"]["func"](interaction, default_duration=0)
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+
+    async def test_sync_forbidden_on_fetch_events(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_session.return_value = {"discussions": self.discussions}
+        interaction.guild.fetch_scheduled_events = AsyncMock(
+            side_effect=discord.Forbidden(MagicMock(), "Missing Permissions")
+        )
+        await self.commands["discussion_sync"]["func"](interaction)
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.assertIn("Manage Events", interaction.followup.send.call_args.args[0])
+
+    async def test_sync_api_error_on_get_session(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_session.side_effect = APIError("unavailable")
+        await self.commands["discussion_sync"]["func"](interaction)
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
 
 
 class TestDiscussionAutocomplete(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -1091,30 +1091,66 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.update_session.return_value = {"success": True}
+        interaction.guild.create_scheduled_event = AsyncMock()
         await self.commands["discussion_add"]["func"](
-            interaction, title="Chapters 1-5", date="2026-06-01", location="Discord"
+            interaction, title="Chapters 1-5", date="2026-06-01", time="18:00"
         )
         self.bot.api.update_session.assert_called_once_with(
             "sess-1", {"discussions": [{"title": "Chapters 1-5", "date": "2026-06-01", "location": "Discord"}]}
         )
+        interaction.guild.create_scheduled_event.assert_called_once()
         self.assertIn("embed", interaction.followup.send.call_args.kwargs)
 
-    async def test_discussion_add_no_location(self):
+    async def test_discussion_add_custom_location(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.update_session.return_value = {"success": True}
+        interaction.guild.create_scheduled_event = AsyncMock()
         await self.commands["discussion_add"]["func"](
-            interaction, title="Intro", date="2026-06-01"
+            interaction, title="Intro", date="2026-06-01", time="19:00", location="Library"
         )
         self.bot.api.update_session.assert_called_once_with(
-            "sess-1", {"discussions": [{"title": "Intro", "date": "2026-06-01"}]}
+            "sess-1", {"discussions": [{"title": "Intro", "date": "2026-06-01", "location": "Library"}]}
         )
+        call_kwargs = interaction.guild.create_scheduled_event.call_args.kwargs
+        self.assertEqual(call_kwargs["location"], "Library")
+
+    async def test_discussion_add_default_location_is_discord(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_session.return_value = {"success": True}
+        interaction.guild.create_scheduled_event = AsyncMock()
+        await self.commands["discussion_add"]["func"](
+            interaction, title="Intro", date="2026-06-01", time="18:00"
+        )
+        saved = self.bot.api.update_session.call_args.args[1]["discussions"][0]
+        self.assertEqual(saved["location"], "Discord")
+        call_kwargs = interaction.guild.create_scheduled_event.call_args.kwargs
+        self.assertEqual(call_kwargs["location"], "Discord")
 
     async def test_discussion_add_invalid_date(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
         await self.commands["discussion_add"]["func"](
-            interaction, title="Intro", date="06/01/2026"
+            interaction, title="Intro", date="06/01/2026", time="18:00"
+        )
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.bot.api.update_session.assert_not_called()
+
+    async def test_discussion_add_invalid_time(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        await self.commands["discussion_add"]["func"](
+            interaction, title="Intro", date="2026-06-01", time="6pm"
+        )
+        self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        self.bot.api.update_session.assert_not_called()
+
+    async def test_discussion_add_invalid_duration(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        await self.commands["discussion_add"]["func"](
+            interaction, title="Intro", date="2026-06-01", time="18:00", duration=0
         )
         self.assertIn("❌", interaction.followup.send.call_args.args[0])
         self.bot.api.update_session.assert_not_called()
@@ -1123,7 +1159,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
         interaction = _make_interaction(user_id="999", is_owner=False)
         self.bot.api.find_club_in_channel.return_value = self.club
         await self.commands["discussion_add"]["func"](
-            interaction, title="Intro", date="2026-06-01"
+            interaction, title="Intro", date="2026-06-01", time="18:00"
         )
         self.assertIn("❌", interaction.followup.send.call_args.args[0])
         self.bot.api.update_session.assert_not_called()
@@ -1134,7 +1170,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
         club_no_session["active_session"] = None
         self.bot.api.find_club_in_channel.return_value = club_no_session
         await self.commands["discussion_add"]["func"](
-            interaction, title="Intro", date="2026-06-01"
+            interaction, title="Intro", date="2026-06-01", time="18:00"
         )
         self.assertIn("❌", interaction.followup.send.call_args.args[0])
         self.bot.api.update_session.assert_not_called()
@@ -1144,9 +1180,37 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.update_session.side_effect = APIError("failed")
         await self.commands["discussion_add"]["func"](
-            interaction, title="Intro", date="2026-06-01"
+            interaction, title="Intro", date="2026-06-01", time="18:00"
         )
         self.assertIn("❌", interaction.followup.send.call_args.args[0])
+
+    async def test_discussion_add_forbidden_warns_but_succeeds(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_session.return_value = {"success": True}
+        interaction.guild.create_scheduled_event = AsyncMock(
+            side_effect=discord.Forbidden(MagicMock(), "Missing Permissions")
+        )
+        await self.commands["discussion_add"]["func"](
+            interaction, title="Intro", date="2026-06-01", time="18:00"
+        )
+        self.bot.api.update_session.assert_called_once()
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        self.assertIn("Manage Events", embed.description)
+
+    async def test_discussion_add_http_exception_warns_but_succeeds(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.update_session.return_value = {"success": True}
+        interaction.guild.create_scheduled_event = AsyncMock(
+            side_effect=discord.HTTPException(MagicMock(), "Bad Request")
+        )
+        await self.commands["discussion_add"]["func"](
+            interaction, title="Intro", date="2026-06-01", time="18:00"
+        )
+        self.bot.api.update_session.assert_called_once()
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        self.assertIn("Discord event creation failed", embed.description)
 
     # ── discussion_update ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds `/discussion_add`, `/discussion_update`, `/discussion_delete`, and `/discussion_sync` admin slash commands for managing discussions on a club's active reading session
- `/discussion_add` creates a Discord scheduled event alongside the Supabase record; embeds `discussion_id:{id}` in the event description for future sync matching
- `/discussion_sync` compares the active session's discussion list against existing guild events (matched by embedded ID) and creates events for any gaps — designed for teams managing discussions via web/mobile who want Discord kept in sync
- All commands scope to a channel's club via the existing `channel` param pattern and require club admin or owner permissions

## Notes

- The Supabase `discussions` table currently has no `time` column; `/discussion_add` accepts a `time` param used only for the Discord event — a backend schema update to persist time is a follow-up
- The bot requires **Manage Events** permission in each guild. For existing servers: **Server Settings → Roles → bot role → enable Manage Events**. For new servers: regenerate the OAuth invite URL with Manage Events checked in the Developer Portal
- `/discussion_sync` is create-only (V1 tradeoff) — it will not update events whose time or title has drifted from the discussion record

## Test plan

- [ ] `make test` passes
- [ ] `make coverage` shows new commands covered
- [ ] `/discussion_add` creates a Supabase discussion and a Discord scheduled event
- [ ] `/discussion_add` without Manage Events permission saves the discussion and shows a warning
- [ ] `/discussion_sync` creates events for discussions added via web/mobile
- [ ] `/discussion_sync` skips discussions that already have an event
- [ ] `/discussion_update` and `/discussion_delete` autocomplete populates from active session

🤖 Generated with [Claude Code](https://claude.com/claude-code)