### PR TITLE
chore: persist discussion time to Supabase on discussion_add

### DIFF
--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -922,7 +922,7 @@ def setup_admin_commands(bot):
 
         session_id = club_data["active_session"]["id"]
         resolved_location = location.strip() if location and location.strip() else "Discord"
-        new_discussion = {"title": title.strip(), "date": date.strip(), "location": resolved_location}
+        new_discussion = {"title": title.strip(), "date": date.strip(), "time": f"{time.strip()}:00", "location": resolved_location}
 
         try:
             bot.api.update_session(session_id, {"discussions": [new_discussion]})

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -1099,7 +1099,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             interaction, title="Chapters 1-5", date="2026-06-01", time="18:00"
         )
         self.bot.api.update_session.assert_called_once_with(
-            "sess-1", {"discussions": [{"title": "Chapters 1-5", "date": "2026-06-01", "location": "Discord"}]}
+            "sess-1", {"discussions": [{"title": "Chapters 1-5", "date": "2026-06-01", "time": "18:00:00", "location": "Discord"}]}
         )
         interaction.guild.create_scheduled_event.assert_called_once()
         call_kwargs = interaction.guild.create_scheduled_event.call_args.kwargs
@@ -1144,7 +1144,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             interaction, title="Intro", date="2026-06-01", time="19:00", location="Library"
         )
         self.bot.api.update_session.assert_called_once_with(
-            "sess-1", {"discussions": [{"title": "Intro", "date": "2026-06-01", "location": "Library"}]}
+            "sess-1", {"discussions": [{"title": "Intro", "date": "2026-06-01", "time": "19:00:00", "location": "Library"}]}
         )
         call_kwargs = interaction.guild.create_scheduled_event.call_args.kwargs
         self.assertEqual(call_kwargs["location"], "Library")


### PR DESCRIPTION
## Summary

- Follow-up to #22: now that the backend `discussions` table has a `time` column, `/discussion_add` includes the time field (`HH:MM:SS`) in the Supabase payload alongside the existing date and location fields

## Test plan

- [ ] `make test` passes
- [ ] `/discussion_add` saves the time to Supabase (verify in the database or API response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)