### PR TITLE
feat(commands): add /vote command for top.gg

### DIFF
--- a/cogs/general_commands.py
+++ b/cogs/general_commands.py
@@ -6,6 +6,7 @@ import os
 import aiohttp
 import discord
 
+from utils.constants import BOT_ID
 from utils.embeds import create_embed
 
 
@@ -189,6 +190,17 @@ def setup_general_commands(bot):
         )
         view = discord.ui.View()
         view.add_item(discord.ui.Button(label="Buy Me a Coffee", url="https://buymeacoffee.com/kluvs"))
+        await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+
+    @bot.tree.command(name="vote", description="Vote for Kluvs on top.gg")
+    async def vote_command(interaction: discord.Interaction):
+        embed = create_embed(
+            title="🗳️ Vote for Kluvs",
+            description="Love using Kluvs? Show your support by voting for us on top.gg!\n\nYour vote helps more book clubs discover Kluvs. Thank you! 📚",
+            color_key="royal"
+        )
+        view = discord.ui.View()
+        view.add_item(discord.ui.Button(label="Vote on top.gg", url=f"https://top.gg/bot/{BOT_ID}"))
         await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
 
     @bot.tree.command(name="bug", description="Report a bug to the Kluvs team")

--- a/tests/test_general_commands.py
+++ b/tests/test_general_commands.py
@@ -38,6 +38,7 @@ class TestGeneralCommands(unittest.IsolatedAsyncioTestCase):
         # Verify commands were registered
         self.assertIn('help', self.commands)
         self.assertIn('usage', self.commands)
+        self.assertIn('vote', self.commands)
 
     @patch('cogs.general_commands.create_embed')
     async def test_help_command(self, mock_create_embed):
@@ -97,6 +98,28 @@ class TestGeneralCommands(unittest.IsolatedAsyncioTestCase):
         
         # Verify the interaction response was sent
         interaction.response.send_message.assert_called_once_with(embed=mock_embed)
+
+    @patch('cogs.general_commands.create_embed')
+    async def test_vote_command(self, mock_create_embed):
+        """Test the vote command"""
+        interaction = AsyncMock()
+        interaction.response = AsyncMock()
+
+        mock_embed = MagicMock()
+        mock_create_embed.return_value = mock_embed
+
+        vote_command = self.commands['vote']['func']
+        await vote_command(interaction)
+
+        mock_create_embed.assert_called_once()
+        _, kwargs = mock_create_embed.call_args
+        self.assertEqual(kwargs['title'], "🗳️ Vote for Kluvs")
+        self.assertEqual(kwargs['color_key'], "royal")
+
+        call_args = interaction.response.send_message.call_args
+        self.assertEqual(call_args.kwargs['embed'], mock_embed)
+        self.assertIsNotNone(call_args.kwargs['view'])
+        self.assertTrue(call_args.kwargs['ephemeral'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -3,6 +3,9 @@ Constants used throughout the bot
 """
 from discord import Color
 
+# Bot identity
+BOT_ID = "1327360422294192199"
+
 # Config variables
 SCHEDULED_MESSAGE_HOUR = 17  # Hour to send sceheduled message
 SCHEDULED_MESSAGE_PERCENTAGE = 0.25  # Chance to send scheduled messages


### PR DESCRIPTION
## Summary
- Adds `/vote` slash command that links users to the Kluvs top.gg voting page
- Stores the bot ID as a constant in `utils/constants.py` (not an env var, since only the prod bot is listed on top.gg)
- Adds unit test covering embed title, color, view presence, and ephemeral flag

## Test plan
- [ ] Run `make test` to confirm new test passes
- [ ] Verify `/vote` appears in Discord slash command list after deploy
- [ ] Confirm the top.gg button links to the correct bot page

🤖 Generated with [Claude Code](https://claude.com/claude-code)