### PR TITLE
feat(admin): add /link_club command for dashboard-created clubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![Discord.py](https://img.shields.io/badge/discord.py-latest-blue.svg)](https://github.com/Rapptz/discord.py)
 
+<div align="center">
+
+[![Discord Bots](https://top.gg/api/widget/1327360422294192199.svg)](https://top.gg/bot/1327360422294192199)
+
+</div>
+
 A focused Discord bot for managing book clubs with session tracking, member management, and AI-powered features.
 
 ## Features

--- a/api/bookclub_api.py
+++ b/api/bookclub_api.py
@@ -260,6 +260,17 @@ class BookClubAPI:
         except requests.exceptions.RequestException as e:
             self._handle_request_error(e, "club", club_id)
     
+    def get_club_by_uuid(self, club_id: str) -> Dict:
+        """Fetch a club by UUID without requiring a guild context."""
+        url = f"{self.functions_url}/club"
+        params = {"id": club_id}
+        try:
+            response = requests.get(url, headers=self.headers, params=params)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            self._handle_request_error(e, "club", club_id)
+
     def get_club_by_discord_channel(self, discord_channel_id: str, guild_id: str) -> Dict:
         """
         Get details for a specific club by Discord channel ID.

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -248,7 +248,7 @@ def setup_admin_commands(bot):
 
     # ── Setup wizard (manage_guild permission only) ──────────────────────────
 
-    @bot.tree.command(name="setup", description="First-run wizard: register server and create a book club")
+    @bot.tree.command(name="setup", description="Create a new book club in this channel. Already have a club on the dashboard? Use /link_club.")
     @app_commands.default_permissions(manage_guild=True)
     @app_commands.guild_only()
     @app_commands.describe(club_name="Name for your new book club")
@@ -595,6 +595,70 @@ def setup_admin_commands(bot):
             await send_ephemeral(interaction,embed=embed)
         except APIError as e:
             await send_ephemeral(interaction,f"❌ Failed to delete club: {e}")
+
+    # ── Link club command (manage_guild permission + Kluvs club admin) ───────
+
+    @bot.tree.command(name="link_club", description="Link a club you created on the Kluvs dashboard to this Discord channel")
+    @app_commands.default_permissions(manage_guild=True)
+    @app_commands.guild_only()
+    @app_commands.describe(club_id="The UUID of the club from the Kluvs dashboard")
+    async def link_club(interaction: discord.Interaction, club_id: str):
+        await interaction.response.defer(ephemeral=True)
+
+        try:
+            club_data = bot.api.get_club_by_uuid(club_id)
+        except ResourceNotFoundError:
+            await send_ephemeral(interaction, "❌ Club not found. Check the UUID and try again.")
+            return
+        except APIError as e:
+            await send_ephemeral(interaction, f"❌ Failed to fetch club: {e}")
+            return
+
+        if club_data.get("discord_channel"):
+            await send_ephemeral(interaction, "❌ This club is already linked to a Discord channel.")
+            return
+
+        caller = bot.api.get_member_by_discord_id(str(interaction.user.id))
+        if not caller:
+            await send_ephemeral(interaction,
+                "❌ Your Discord account isn't linked to a Kluvs account. "
+                "Please sign in on the Kluvs dashboard and link your Discord account first."
+            )
+            return
+
+        caller_role = next(
+            (c.get("role") for c in caller.get("clubs", []) if c.get("id") == club_id),
+            None
+        )
+        if caller_role not in ("admin", "owner"):
+            await send_ephemeral(interaction, "❌ You must be a club admin or owner to link it to Discord.")
+            return
+
+        try:
+            bot.api.register_server(str(interaction.guild.id), interaction.guild.name)
+        except APIError as e:
+            err = str(e).lower()
+            if not any(k in err for k in ("already", "duplicate", "409")):
+                await send_ephemeral(interaction, f"❌ Failed to register server: {e}")
+                return
+
+        try:
+            bot.api.update_club(
+                club_id,
+                {"discord_channel": str(interaction.channel.id)},
+                str(interaction.guild.id)
+            )
+        except APIError as e:
+            await send_ephemeral(interaction, f"❌ Failed to link club: {e}")
+            return
+
+        club_name = club_data.get("name", club_id)
+        embed = create_embed(
+            title="✅ Club Linked",
+            description=f"Club **{club_name}** is now linked to {interaction.channel.mention}.",
+            color_key="success"
+        )
+        await send_ephemeral(interaction, embed=embed)
 
     # ── Member commands (club admin+) ─────────────────────────────────────────
 

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -208,6 +208,147 @@ class TestSetupCommand(unittest.IsolatedAsyncioTestCase):
             self.assertIn("embed", interaction.followup.send.call_args.kwargs)
 
 
+class TestLinkClubCommand(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.bot, self.commands = _make_bot()
+        self.club_id = "club-uuid-1"
+
+    def _make_club(self, discord_channel=None):
+        return {
+            "id": self.club_id,
+            "name": "Dashboard Club",
+            "discord_channel": discord_channel,
+        }
+
+    def _make_caller(self, role=None):
+        clubs = []
+        if role:
+            clubs = [{"id": self.club_id, "name": "Dashboard Club", "role": role}]
+        return {"id": 42, "name": "Test User", "discord_id": "111", "clubs": clubs}
+
+    async def test_link_club_success_owner(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.get_club_by_uuid.return_value = self._make_club()
+        self.bot.api.get_member_by_discord_id.return_value = self._make_caller(role="owner")
+        self.bot.api.register_server.return_value = {"success": True}
+        self.bot.api.update_club.return_value = {"success": True}
+
+        await self.commands["link_club"]["func"](interaction, club_id=self.club_id)
+
+        self.bot.api.update_club.assert_called_once()
+        call_args = self.bot.api.update_club.call_args[0]
+        self.assertEqual(call_args[0], self.club_id)
+        self.assertIn("discord_channel", call_args[1])
+        interaction.followup.send.assert_called_once()
+        self.assertIn("embed", interaction.followup.send.call_args.kwargs)
+
+    async def test_link_club_success_admin(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.get_club_by_uuid.return_value = self._make_club()
+        self.bot.api.get_member_by_discord_id.return_value = self._make_caller(role="admin")
+        self.bot.api.register_server.return_value = {"success": True}
+        self.bot.api.update_club.return_value = {"success": True}
+
+        await self.commands["link_club"]["func"](interaction, club_id=self.club_id)
+
+        self.bot.api.update_club.assert_called_once()
+
+    async def test_link_club_club_not_found(self):
+        interaction = _make_interaction()
+        self.bot.api.get_club_by_uuid.side_effect = ResourceNotFoundError("club", "bad-id")
+
+        await self.commands["link_club"]["func"](interaction, club_id="bad-id")
+
+        self.bot.api.update_club.assert_not_called()
+        msg = interaction.followup.send.call_args
+        self.assertIn("❌", msg.args[0] if msg.args else str(msg.kwargs))
+
+    async def test_link_club_already_linked(self):
+        interaction = _make_interaction()
+        self.bot.api.get_club_by_uuid.return_value = self._make_club(discord_channel="999")
+
+        await self.commands["link_club"]["func"](interaction, club_id=self.club_id)
+
+        self.bot.api.update_club.assert_not_called()
+        msg = interaction.followup.send.call_args
+        self.assertIn("❌", msg.args[0] if msg.args else str(msg.kwargs))
+
+    async def test_link_club_discord_not_linked(self):
+        interaction = _make_interaction()
+        self.bot.api.get_club_by_uuid.return_value = self._make_club()
+        self.bot.api.get_member_by_discord_id.return_value = None
+
+        await self.commands["link_club"]["func"](interaction, club_id=self.club_id)
+
+        self.bot.api.update_club.assert_not_called()
+        msg = interaction.followup.send.call_args
+        self.assertIn("❌", msg.args[0] if msg.args else str(msg.kwargs))
+
+    async def test_link_club_insufficient_role_member(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.get_club_by_uuid.return_value = self._make_club()
+        self.bot.api.get_member_by_discord_id.return_value = self._make_caller(role="member")
+
+        await self.commands["link_club"]["func"](interaction, club_id=self.club_id)
+
+        self.bot.api.update_club.assert_not_called()
+        msg = interaction.followup.send.call_args
+        self.assertIn("❌", msg.args[0] if msg.args else str(msg.kwargs))
+
+    async def test_link_club_insufficient_role_not_in_club(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.get_club_by_uuid.return_value = self._make_club()
+        self.bot.api.get_member_by_discord_id.return_value = self._make_caller(role=None)
+
+        await self.commands["link_club"]["func"](interaction, club_id=self.club_id)
+
+        self.bot.api.update_club.assert_not_called()
+
+    async def test_link_club_register_server_idempotent(self):
+        """register_server raising a duplicate error should not abort the flow."""
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.get_club_by_uuid.return_value = self._make_club()
+        self.bot.api.get_member_by_discord_id.return_value = self._make_caller(role="owner")
+        self.bot.api.register_server.side_effect = APIError("409 already exists")
+        self.bot.api.update_club.return_value = {"success": True}
+
+        await self.commands["link_club"]["func"](interaction, club_id=self.club_id)
+
+        self.bot.api.update_club.assert_called_once()
+
+    async def test_link_club_register_server_hard_fail(self):
+        """A non-duplicate register_server error should abort."""
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.get_club_by_uuid.return_value = self._make_club()
+        self.bot.api.get_member_by_discord_id.return_value = self._make_caller(role="owner")
+        self.bot.api.register_server.side_effect = APIError("connection refused")
+
+        await self.commands["link_club"]["func"](interaction, club_id=self.club_id)
+
+        self.bot.api.update_club.assert_not_called()
+
+    async def test_link_club_update_fails(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.get_club_by_uuid.return_value = self._make_club()
+        self.bot.api.get_member_by_discord_id.return_value = self._make_caller(role="owner")
+        self.bot.api.register_server.return_value = {"success": True}
+        self.bot.api.update_club.side_effect = APIError("update failed")
+
+        await self.commands["link_club"]["func"](interaction, club_id=self.club_id)
+
+        msg = interaction.followup.send.call_args
+        content = msg.args[0] if msg.args else str(msg.kwargs)
+        self.assertIn("❌", content)
+
+    async def test_link_club_fetch_api_error(self):
+        interaction = _make_interaction()
+        self.bot.api.get_club_by_uuid.side_effect = APIError("server error")
+
+        await self.commands["link_club"]["func"](interaction, club_id=self.club_id)
+
+        self.bot.api.update_club.assert_not_called()
+
+
 class TestServerCommands(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.bot, self.commands = _make_bot()

--- a/tests/test_bookclub_api.py
+++ b/tests/test_bookclub_api.py
@@ -154,6 +154,41 @@ class TestBookClubAPI(unittest.TestCase):
             params={"id": "club-1", "server_id": self.test_guild_id}
         )
 
+    @patch('requests.get')
+    def test_get_club_by_uuid(self, mock_get):
+        """Test get_club_by_uuid fetches club by ID without guild context."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "id": "club-uuid-1",
+            "name": "Dashboard Club",
+            "discord_channel": None,
+            "members": []
+        }
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+
+        result = self.api.get_club_by_uuid("club-uuid-1")
+
+        self.assertEqual(result["id"], "club-uuid-1")
+        self.assertEqual(result["name"], "Dashboard Club")
+        mock_get.assert_called_once_with(
+            "http://test-url.supabase.co/functions/v1/club",
+            headers=self.api.headers,
+            params={"id": "club-uuid-1"}
+        )
+
+    @patch('requests.get')
+    def test_get_club_by_uuid_not_found(self, mock_get):
+        """Test get_club_by_uuid raises ResourceNotFoundError on 404."""
+        from requests.exceptions import HTTPError
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status.side_effect = HTTPError(response=mock_response)
+        mock_get.return_value = mock_response
+
+        with self.assertRaises(ResourceNotFoundError):
+            self.api.get_club_by_uuid("nonexistent-uuid")
+
     @patch('requests.post')
     def test_create_club(self, mock_post):
         """Test create_club method with guild_id."""


### PR DESCRIPTION
## Summary

- Adds `/link_club` slash command so server admins can link a club created on the Kluvs dashboard to a Discord channel, without going through `/setup`
- Adds `get_club_by_uuid` API method for a guild-agnostic club lookup (used to fetch club data and check if it's already linked)
- Updates `/setup` description to surface `/link_club` as the alternative for dashboard-created clubs

## Details

The `/link_club` flow:
1. Fetches the club by UUID — rejects if not found or already linked to a channel
2. Verifies the caller has a linked Kluvs account via `get_member_by_discord_id`
3. Confirms the caller holds `admin` or `owner` role in that club by checking their member record's `clubs` list (not the club's member list, which doesn't expose `discord_id`)
4. Registers the Discord server idempotently, then patches `discord_channel` + `server_id` on the club via `PUT /club`

## Test plan

- [ ] Happy path: valid UUID, caller is club owner → club linked, success embed shown
- [ ] Club already has a `discord_channel` → blocked with clear error
- [ ] Caller's Discord account not linked to a Kluvs account → blocked
- [ ] Caller is a club member (not admin/owner) → blocked
- [ ] Bogus UUID → not found error
- [ ] Depends on `PUT /club` accepting `server_id` as an updatable field (covered by kluvs-backend `epic/club-sharing-invite-links`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)