### PR TITLE
Extract discussion CRUD into standalone endpoint

### DIFF
--- a/api/bookclub_api.py
+++ b/api/bookclub_api.py
@@ -750,6 +750,73 @@ class BookClubAPI:
             title, author, external_google_id, edition, year, isbn, page_count, image_url
         )
 
+    def create_discussion(self, discussion_data: Dict) -> Dict:
+        """
+        Create a new discussion for a session.
+
+        Args:
+            discussion_data: Dict containing discussion data
+                Example:
+                {
+                    "session_id": "session-id-1",
+                    "title": "Chapters 1-3",
+                    "date": "2023-11-15",
+                    "time": "18:00:00",  # Optional
+                    "location": "Library"  # Optional
+                }
+
+        Returns:
+            Dict containing the created discussion (including server-generated id)
+
+        Raises:
+            ValidationError: If the discussion data is invalid
+            ResourceNotFoundError: If the session doesn't exist
+            AuthenticationError: If there's an authentication issue
+            APIError: For other API errors
+        """
+        url = f"{self.functions_url}/discussion"
+
+        try:
+            response = requests.post(url, headers=self.headers, json=discussion_data)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            self._handle_request_error(e, "discussion")
+
+    def update_discussion(self, discussion_id: str, update_data: Dict) -> Dict:
+        """
+        Update a discussion's details.
+
+        Args:
+            discussion_id: The ID of the discussion to update
+            update_data: Dict containing fields to update
+                Example:
+                {
+                    "title": "Updated Discussion",  # Optional
+                    "date": "2023-11-20",  # Optional
+                    "time": "18:00:00",  # Optional
+                    "location": "Library"  # Optional
+                }
+
+        Returns:
+            Dict containing the updated discussion
+
+        Raises:
+            ResourceNotFoundError: If the discussion doesn't exist
+            ValidationError: If the discussion data is invalid
+            AuthenticationError: If there's an authentication issue
+            APIError: For other API errors
+        """
+        url = f"{self.functions_url}/discussion"
+        data = {"id": discussion_id, **update_data}
+
+        try:
+            response = requests.put(url, headers=self.headers, json=data)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            self._handle_request_error(e, "discussion", discussion_id)
+
     def delete_discussion(self, discussion_id: str) -> Dict:
         """
         Delete a specific discussion by ID.
@@ -771,6 +838,8 @@ class BookClubAPI:
         try:
             response = requests.delete(url, headers=self.headers, params=params)
             response.raise_for_status()
+            if response.status_code == 204 or not response.content:
+                return {"success": True, "message": "Discussion deleted successfully"}
             return response.json()
         except requests.exceptions.RequestException as e:
             self._handle_request_error(e, "discussion", discussion_id)

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -1152,24 +1152,12 @@ def setup_admin_commands(bot):
         new_discussion = {"title": title.strip(), "date": date.strip(), "time": f"{time.strip()}:00", "location": resolved_location}
 
         try:
-            bot.api.update_session(session_id, {"discussions": [new_discussion]})
+            created_discussion = bot.api.create_discussion({"session_id": session_id, **new_discussion})
         except APIError as e:
             await send_ephemeral(interaction,f"❌ Failed to add discussion: {e}")
             return
 
-        # Retrieve the server-assigned discussion ID so we can embed it in the event.
-        disc_id = None
-        try:
-            session = bot.api.get_session(session_id)
-            match = next(
-                (d for d in session.get("discussions", [])
-                 if d.get("title") == new_discussion["title"] and d.get("date") == new_discussion["date"]),
-                None
-            )
-            if match:
-                disc_id = match["id"]
-        except APIError:
-            pass  # Non-fatal — event will be created without an embedded ID
+        disc_id = created_discussion.get("id")
 
         # Build timezone-aware datetimes for the Discord event (explicitly UTC)
         start_dt = datetime.strptime(f"{date} {time}", "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc)
@@ -1278,7 +1266,7 @@ def setup_admin_commands(bot):
             updated["location"] = resolved_location
 
         try:
-            bot.api.update_session(session_id, {"discussions": [updated]})
+            bot.api.update_discussion(discussion_id, {k: v for k, v in updated.items() if k != "id"})
             description = f"Updated **{updated['title']}** on {updated['date']}"
             if updated.get("location"):
                 description += f" at {updated['location']}"
@@ -1335,9 +1323,8 @@ def setup_admin_commands(bot):
             await send_ephemeral(interaction,embed=embed)
             return
 
-        session_id = club_data["active_session"]["id"]
         try:
-            bot.api.update_session(session_id, {"discussion_ids_to_delete": [discussion_id]})
+            bot.api.delete_discussion(discussion_id)
             embed = create_embed(
                 title="✅ Discussion Deleted",
                 description="The discussion has been removed from the session.",

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -1489,16 +1489,15 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
     async def test_discussion_add_success(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
-        self.bot.api.update_session.return_value = {"success": True}
-        self.bot.api.get_session.return_value = {
-            "discussions": [{"id": "disc-new", "title": "Chapters 1-5", "date": "2026-06-01", "location": "Discord"}]
+        self.bot.api.create_discussion.return_value = {
+            "id": "disc-new", "title": "Chapters 1-5", "date": "2026-06-01", "location": "Discord"
         }
         interaction.guild.create_scheduled_event = AsyncMock()
         await self.commands["discussion_add"]["func"](
             interaction, title="Chapters 1-5", date="2026-06-01", time="18:00"
         )
-        self.bot.api.update_session.assert_called_once_with(
-            "sess-1", {"discussions": [{"title": "Chapters 1-5", "date": "2026-06-01", "time": "18:00:00", "location": "Discord"}]}
+        self.bot.api.create_discussion.assert_called_once_with(
+            {"session_id": "sess-1", "title": "Chapters 1-5", "date": "2026-06-01", "time": "18:00:00", "location": "Discord"}
         )
         interaction.guild.create_scheduled_event.assert_called_once()
         call_kwargs = interaction.guild.create_scheduled_event.call_args.kwargs
@@ -1508,10 +1507,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
     async def test_discussion_add_embeds_id_in_event_description(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
-        self.bot.api.update_session.return_value = {"success": True}
-        self.bot.api.get_session.return_value = {
-            "discussions": [{"id": "disc-abc", "title": "Intro", "date": "2026-06-01"}]
-        }
+        self.bot.api.create_discussion.return_value = {"id": "disc-abc", "title": "Intro", "date": "2026-06-01"}
         interaction.guild.create_scheduled_event = AsyncMock()
         await self.commands["discussion_add"]["func"](
             interaction, title="Intro", date="2026-06-01", time="18:00"
@@ -1519,11 +1515,10 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
         desc = interaction.guild.create_scheduled_event.call_args.kwargs["description"]
         self.assertIn("discussion_id:disc-abc", desc)
 
-    async def test_discussion_add_event_created_without_id_on_get_session_failure(self):
+    async def test_discussion_add_event_created_without_id_when_response_lacks_id(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
-        self.bot.api.update_session.return_value = {"success": True}
-        self.bot.api.get_session.side_effect = APIError("unavailable")
+        self.bot.api.create_discussion.return_value = {"title": "Intro", "date": "2026-06-01"}
         interaction.guild.create_scheduled_event = AsyncMock()
         await self.commands["discussion_add"]["func"](
             interaction, title="Intro", date="2026-06-01", time="18:00"
@@ -1536,14 +1531,13 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
     async def test_discussion_add_custom_location(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
-        self.bot.api.update_session.return_value = {"success": True}
-        self.bot.api.get_session.return_value = {"discussions": []}
+        self.bot.api.create_discussion.return_value = {"id": "disc-new"}
         interaction.guild.create_scheduled_event = AsyncMock()
         await self.commands["discussion_add"]["func"](
             interaction, title="Intro", date="2026-06-01", time="19:00", location="Library"
         )
-        self.bot.api.update_session.assert_called_once_with(
-            "sess-1", {"discussions": [{"title": "Intro", "date": "2026-06-01", "time": "19:00:00", "location": "Library"}]}
+        self.bot.api.create_discussion.assert_called_once_with(
+            {"session_id": "sess-1", "title": "Intro", "date": "2026-06-01", "time": "19:00:00", "location": "Library"}
         )
         call_kwargs = interaction.guild.create_scheduled_event.call_args.kwargs
         self.assertEqual(call_kwargs["location"], "Library")
@@ -1551,13 +1545,12 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
     async def test_discussion_add_default_location_is_discord(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
-        self.bot.api.update_session.return_value = {"success": True}
-        self.bot.api.get_session.return_value = {"discussions": []}
+        self.bot.api.create_discussion.return_value = {"id": "disc-new"}
         interaction.guild.create_scheduled_event = AsyncMock()
         await self.commands["discussion_add"]["func"](
             interaction, title="Intro", date="2026-06-01", time="18:00"
         )
-        saved = self.bot.api.update_session.call_args.args[1]["discussions"][0]
+        saved = self.bot.api.create_discussion.call_args.args[0]
         self.assertEqual(saved["location"], "Discord")
         call_kwargs = interaction.guild.create_scheduled_event.call_args.kwargs
         self.assertEqual(call_kwargs["location"], "Discord")
@@ -1573,7 +1566,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             self.assertIn("❌", interaction.followup.send.call_args.args[0])
         else:
             self.assertIn("embed", interaction.followup.send.call_args.kwargs)
-        self.bot.api.update_session.assert_not_called()
+        self.bot.api.create_discussion.assert_not_called()
 
     async def test_discussion_add_invalid_time(self):
         interaction = _make_interaction(user_id="111")
@@ -1586,7 +1579,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             self.assertIn("❌", interaction.followup.send.call_args.args[0])
         else:
             self.assertIn("embed", interaction.followup.send.call_args.kwargs)
-        self.bot.api.update_session.assert_not_called()
+        self.bot.api.create_discussion.assert_not_called()
 
     async def test_discussion_add_invalid_duration(self):
         interaction = _make_interaction(user_id="111")
@@ -1599,7 +1592,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             self.assertIn("❌", interaction.followup.send.call_args.args[0])
         else:
             self.assertIn("embed", interaction.followup.send.call_args.kwargs)
-        self.bot.api.update_session.assert_not_called()
+        self.bot.api.create_discussion.assert_not_called()
 
     async def test_discussion_add_permission_denied(self):
         interaction = _make_interaction(user_id="999", is_owner=False)
@@ -1612,7 +1605,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             self.assertIn("❌", interaction.followup.send.call_args.args[0])
         else:
             self.assertIn("embed", interaction.followup.send.call_args.kwargs)
-        self.bot.api.update_session.assert_not_called()
+        self.bot.api.create_discussion.assert_not_called()
 
     async def test_discussion_add_no_session(self):
         interaction = _make_interaction(user_id="111")
@@ -1627,12 +1620,12 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             self.assertIn("❌", interaction.followup.send.call_args.args[0])
         else:
             self.assertIn("embed", interaction.followup.send.call_args.kwargs)
-        self.bot.api.update_session.assert_not_called()
+        self.bot.api.create_discussion.assert_not_called()
 
     async def test_discussion_add_api_error(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
-        self.bot.api.update_session.side_effect = APIError("failed")
+        self.bot.api.create_discussion.side_effect = APIError("failed")
         await self.commands["discussion_add"]["func"](
             interaction, title="Intro", date="2026-06-01", time="18:00"
         )
@@ -1645,30 +1638,28 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
     async def test_discussion_add_forbidden_warns_but_succeeds(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
-        self.bot.api.update_session.return_value = {"success": True}
-        self.bot.api.get_session.return_value = {"discussions": []}
+        self.bot.api.create_discussion.return_value = {"id": "disc-new"}
         interaction.guild.create_scheduled_event = AsyncMock(
             side_effect=discord.Forbidden(MagicMock(), "Missing Permissions")
         )
         await self.commands["discussion_add"]["func"](
             interaction, title="Intro", date="2026-06-01", time="18:00"
         )
-        self.bot.api.update_session.assert_called_once()
+        self.bot.api.create_discussion.assert_called_once()
         embed = interaction.followup.send.call_args.kwargs["embed"]
         self.assertIn("Manage Events", embed.description)
 
     async def test_discussion_add_http_exception_warns_but_succeeds(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
-        self.bot.api.update_session.return_value = {"success": True}
-        self.bot.api.get_session.return_value = {"discussions": []}
+        self.bot.api.create_discussion.return_value = {"id": "disc-new"}
         interaction.guild.create_scheduled_event = AsyncMock(
             side_effect=discord.HTTPException(MagicMock(), "Bad Request")
         )
         await self.commands["discussion_add"]["func"](
             interaction, title="Intro", date="2026-06-01", time="18:00"
         )
-        self.bot.api.update_session.assert_called_once()
+        self.bot.api.create_discussion.assert_called_once()
         embed = interaction.followup.send.call_args.kwargs["embed"]
         self.assertIn("Discord event creation failed", embed.description)
 
@@ -1678,13 +1669,13 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.get_session.return_value = self.session_with_discussions
-        self.bot.api.update_session.return_value = {"success": True}
+        self.bot.api.update_discussion.return_value = {"success": True}
         await self.commands["discussion_update"]["func"](
             interaction, discussion_id="disc-1", title="Updated Title"
         )
-        self.bot.api.update_session.assert_called_once_with(
-            "sess-1",
-            {"discussions": [{"id": "disc-1", "title": "Updated Title", "date": "2026-06-01", "location": "Discord"}]}
+        self.bot.api.update_discussion.assert_called_once_with(
+            "disc-1",
+            {"title": "Updated Title", "date": "2026-06-01", "location": "Discord"}
         )
         self.assertIn("embed", interaction.followup.send.call_args.kwargs)
 
@@ -1699,7 +1690,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             self.assertIn("❌", interaction.followup.send.call_args.args[0])
         else:
             self.assertIn("embed", interaction.followup.send.call_args.kwargs)
-        self.bot.api.update_session.assert_not_called()
+        self.bot.api.update_discussion.assert_not_called()
 
     async def test_discussion_update_invalid_date(self):
         interaction = _make_interaction(user_id="111")
@@ -1712,7 +1703,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             self.assertIn("❌", interaction.followup.send.call_args.args[0])
         else:
             self.assertIn("embed", interaction.followup.send.call_args.kwargs)
-        self.bot.api.update_session.assert_not_called()
+        self.bot.api.update_discussion.assert_not_called()
 
     async def test_discussion_update_not_found(self):
         interaction = _make_interaction(user_id="111")
@@ -1726,7 +1717,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             self.assertIn("❌", interaction.followup.send.call_args.args[0])
         else:
             self.assertIn("embed", interaction.followup.send.call_args.kwargs)
-        self.bot.api.update_session.assert_not_called()
+        self.bot.api.update_discussion.assert_not_called()
 
     async def test_discussion_update_permission_denied(self):
         interaction = _make_interaction(user_id="999", is_owner=False)
@@ -1739,7 +1730,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             self.assertIn("❌", interaction.followup.send.call_args.args[0])
         else:
             self.assertIn("embed", interaction.followup.send.call_args.kwargs)
-        self.bot.api.update_session.assert_not_called()
+        self.bot.api.update_discussion.assert_not_called()
 
     async def test_discussion_update_no_session(self):
         interaction = _make_interaction(user_id="111")
@@ -1754,7 +1745,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             self.assertIn("❌", interaction.followup.send.call_args.args[0])
         else:
             self.assertIn("embed", interaction.followup.send.call_args.kwargs)
-        self.bot.api.update_session.assert_not_called()
+        self.bot.api.update_discussion.assert_not_called()
 
     async def test_discussion_update_api_error_on_get(self):
         interaction = _make_interaction(user_id="111")
@@ -1768,13 +1759,13 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             self.assertIn("❌", interaction.followup.send.call_args.args[0])
         else:
             self.assertIn("embed", interaction.followup.send.call_args.kwargs)
-        self.bot.api.update_session.assert_not_called()
+        self.bot.api.update_discussion.assert_not_called()
 
     async def test_discussion_update_api_error_on_update(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.get_session.return_value = self.session_with_discussions
-        self.bot.api.update_session.side_effect = APIError("update failed")
+        self.bot.api.update_discussion.side_effect = APIError("update failed")
         await self.commands["discussion_update"]["func"](
             interaction, discussion_id="disc-1", title="New"
         )
@@ -1789,12 +1780,10 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
     async def test_discussion_delete_success(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
-        self.bot.api.update_session.return_value = {"success": True}
+        self.bot.api.delete_discussion.return_value = {"success": True}
         with patch.object(discord.ui.View, "wait", _auto_confirm()):
             await self.commands["discussion_delete"]["func"](interaction, discussion_id="disc-1")
-        self.bot.api.update_session.assert_called_once_with(
-            "sess-1", {"discussion_ids_to_delete": ["disc-1"]}
-        )
+        self.bot.api.delete_discussion.assert_called_once_with("disc-1")
         self.assertIn("embed", interaction.followup.send.call_args.kwargs)
 
     async def test_discussion_delete_cancelled(self):
@@ -1802,7 +1791,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
         self.bot.api.find_club_in_channel.return_value = self.club
         with patch.object(discord.ui.View, "wait", _no_confirm()):
             await self.commands["discussion_delete"]["func"](interaction, discussion_id="disc-1")
-        self.bot.api.update_session.assert_not_called()
+        self.bot.api.delete_discussion.assert_not_called()
         # Check for cancellation message in either positional or keyword arguments
         if interaction.followup.send.call_args.args:
             self.assertIn("cancelled", interaction.followup.send.call_args.args[0])
@@ -1818,7 +1807,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             self.assertIn("❌", interaction.followup.send.call_args.args[0])
         else:
             self.assertIn("embed", interaction.followup.send.call_args.kwargs)
-        self.bot.api.update_session.assert_not_called()
+        self.bot.api.delete_discussion.assert_not_called()
 
     async def test_discussion_delete_no_session(self):
         interaction = _make_interaction(user_id="111")
@@ -1831,12 +1820,12 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             self.assertIn("❌", interaction.followup.send.call_args.args[0])
         else:
             self.assertIn("embed", interaction.followup.send.call_args.kwargs)
-        self.bot.api.update_session.assert_not_called()
+        self.bot.api.delete_discussion.assert_not_called()
 
     async def test_discussion_delete_api_error(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
-        self.bot.api.update_session.side_effect = APIError("delete failed")
+        self.bot.api.delete_discussion.side_effect = APIError("delete failed")
         with patch.object(discord.ui.View, "wait", _auto_confirm()):
             await self.commands["discussion_delete"]["func"](interaction, discussion_id="disc-1")
         self.assertIn("❌", interaction.followup.send.call_args_list[-1].args[0])

--- a/tests/test_bookclub_api.py
+++ b/tests/test_bookclub_api.py
@@ -1189,6 +1189,91 @@ class TestBookClubAPI(unittest.TestCase):
         self.assertEqual(call_args['page_count'], 255)
         self.assertEqual(call_args['image_url'], "https://example.com/foundation.jpg")
 
+    @patch('requests.post')
+    def test_create_discussion(self, mock_post):
+        """Test create_discussion with valid data."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "id": "discussion-new",
+            "session_id": "session-1",
+            "title": "Chapters 1-3",
+            "date": "2025-05-01",
+            "time": "18:00:00",
+            "location": "Library"
+        }
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        discussion_data = {
+            "session_id": "session-1",
+            "title": "Chapters 1-3",
+            "date": "2025-05-01",
+            "time": "18:00:00",
+            "location": "Library"
+        }
+
+        result = self.api.create_discussion(discussion_data)
+
+        self.assertEqual(result["id"], "discussion-new")
+        self.assertEqual(result["title"], "Chapters 1-3")
+        mock_post.assert_called_once_with(
+            "http://test-url.supabase.co/functions/v1/discussion",
+            headers=self.api.headers,
+            json=discussion_data
+        )
+
+    @patch('requests.post')
+    def test_create_discussion_session_not_found(self, mock_post):
+        """Test create_discussion when the parent session doesn't exist."""
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.text = "Session not found"
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "404 Client Error", response=mock_response
+        )
+        mock_post.return_value = mock_response
+
+        with self.assertRaises(ResourceNotFoundError):
+            self.api.create_discussion({"session_id": "missing-session", "title": "Chapters 1-3", "date": "2025-05-01"})
+
+    @patch('requests.put')
+    def test_update_discussion(self, mock_put):
+        """Test update_discussion with valid data."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "id": "discussion-123",
+            "title": "Updated Discussion",
+            "date": "2025-05-10",
+            "location": "Online"
+        }
+        mock_response.raise_for_status = Mock()
+        mock_put.return_value = mock_response
+
+        update_data = {"title": "Updated Discussion", "date": "2025-05-10", "location": "Online"}
+
+        result = self.api.update_discussion("discussion-123", update_data)
+
+        self.assertEqual(result["title"], "Updated Discussion")
+        mock_put.assert_called_once_with(
+            "http://test-url.supabase.co/functions/v1/discussion",
+            headers=self.api.headers,
+            json={"id": "discussion-123", **update_data}
+        )
+
+    @patch('requests.put')
+    def test_update_discussion_not_found(self, mock_put):
+        """Test update_discussion when the discussion doesn't exist."""
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.text = "Discussion not found"
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "404 Client Error", response=mock_response
+        )
+        mock_put.return_value = mock_response
+
+        with self.assertRaises(ResourceNotFoundError):
+            self.api.update_discussion("missing-discussion", {"title": "New Title"})
+
     @patch('requests.delete')
     def test_delete_discussion_success(self, mock_delete):
         """Test delete_discussion with valid ID."""
@@ -1200,7 +1285,40 @@ class TestBookClubAPI(unittest.TestCase):
         result = self.api.delete_discussion("discussion-123")
 
         self.assertTrue(result["success"])
-        mock_delete.assert_called_once()
+        mock_delete.assert_called_once_with(
+            "http://test-url.supabase.co/functions/v1/discussion",
+            headers=self.api.headers,
+            params={"id": "discussion-123"}
+        )
+
+    @patch('requests.delete')
+    def test_delete_discussion_empty_response_body(self, mock_delete):
+        """Test delete_discussion when the API returns a 204 with no body."""
+        mock_response = Mock()
+        mock_response.status_code = 204
+        mock_response.content = b""
+        mock_response.raise_for_status = Mock()
+        mock_delete.return_value = mock_response
+
+        result = self.api.delete_discussion("discussion-123")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["message"], "Discussion deleted successfully")
+        mock_response.json.assert_not_called()
+
+    @patch('requests.delete')
+    def test_delete_discussion_not_found(self, mock_delete):
+        """Test delete_discussion when the discussion doesn't exist."""
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.text = "Discussion not found"
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "404 Client Error", response=mock_response
+        )
+        mock_delete.return_value = mock_response
+
+        with self.assertRaises(ResourceNotFoundError):
+            self.api.delete_discussion("missing-discussion")
 
     @patch('requests.post')
     def test_create_club_connection_error(self, mock_post):


### PR DESCRIPTION
## Summary
- Adds `create_discussion` and `update_discussion` to `BookClubAPI`, and routes `/discussion_add`, `/discussion_update`, and `/discussion_delete` through the dedicated `/discussion` endpoint methods instead of overloading `update_session` with `discussions` / `discussion_ids_to_delete` payloads
- `discussion_add` now gets the server-generated discussion ID directly from the create response, removing the previous fragile title+date lookup via `get_session`
- `discussion_update`/`discussion_delete` now target a single discussion record instead of replacing the session's entire `discussions` array
- `delete_discussion` now handles `204`/empty-body responses gracefully

## Test plan
- [x] Added/updated unit tests for `create_discussion`, `update_discussion`, and the new `delete_discussion` empty-body/not-found paths in `tests/test_bookclub_api.py`
- [x] Rewired `TestDiscussionCommands` in `tests/test_admin_commands.py` to assert against the new `create_discussion`/`update_discussion`/`delete_discussion` calls
- [x] `make test` — all 322 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)