### PR TITLE
Migrate discussions to scheduled_at timestamptz

### DIFF
--- a/api/bookclub_api.py
+++ b/api/bookclub_api.py
@@ -612,7 +612,7 @@ class BookClubAPI:
                     "discussions": [  # Optional
                         {
                             "title": "Chapters 1-3",
-                            "date": "2023-11-15",
+                            "scheduled_at": "2023-11-15T18:00:00+00:00",
                             "location": "Library"  # Optional
                         }
                     ]
@@ -656,12 +656,12 @@ class BookClubAPI:
                         {
                             "id": "existing-discussion-id",  # Include for existing discussions
                             "title": "Updated Discussion",
-                            "date": "2023-11-20",
+                            "scheduled_at": "2023-11-20T18:00:00+00:00",
                             "location": "Library"  # Optional
                         },
                         {
                             "title": "New Discussion",  # New discussion (no ID)
-                            "date": "2023-12-01",
+                            "scheduled_at": "2023-12-01T18:00:00+00:00",
                             "location": "Online"  # Optional
                         }
                     ],
@@ -760,8 +760,7 @@ class BookClubAPI:
                 {
                     "session_id": "session-id-1",
                     "title": "Chapters 1-3",
-                    "date": "2023-11-15",
-                    "time": "18:00:00",  # Optional
+                    "scheduled_at": "2023-11-15T18:00:00+00:00",
                     "location": "Library"  # Optional
                 }
 
@@ -793,8 +792,7 @@ class BookClubAPI:
                 Example:
                 {
                     "title": "Updated Discussion",  # Optional
-                    "date": "2023-11-20",  # Optional
-                    "time": "18:00:00",  # Optional
+                    "scheduled_at": "2023-11-20T18:00:00+00:00",  # Optional
                     "location": "Library"  # Optional
                 }
 

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -9,6 +9,7 @@ import discord
 from discord import app_commands
 
 from utils.embeds import create_embed
+from utils.datetime_helpers import to_discord_timestamp, format_human_readable
 from api.bookclub_api import APIError, ResourceNotFoundError
 
 # Marker embedded in Discord event descriptions so discussion_sync can match them.
@@ -28,7 +29,9 @@ async def discussion_autocomplete(interaction: discord.Interaction, current: str
         discussions = session.get("discussions", [])
         choices = []
         for d in discussions:
-            label = f"{d.get('title', 'Untitled')} — {d.get('date', '')}"
+            scheduled_at = d.get("scheduled_at", "")
+            when = format_human_readable(scheduled_at) if scheduled_at else ""
+            label = f"{d.get('title', 'Untitled')} — {when}"
             if not current or current.lower() in label.lower():
                 choices.append(app_commands.Choice(name=label[:100], value=d["id"]))
         return choices[:25]
@@ -1149,7 +1152,8 @@ def setup_admin_commands(bot):
 
         session_id = club_data["active_session"]["id"]
         resolved_location = location.strip() if location and location.strip() else "Discord"
-        new_discussion = {"title": title.strip(), "date": date.strip(), "time": f"{time.strip()}:00", "location": resolved_location}
+        scheduled_at = datetime.strptime(f"{date} {time}", "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc).isoformat()
+        new_discussion = {"title": title.strip(), "scheduled_at": scheduled_at, "location": resolved_location}
 
         try:
             created_discussion = bot.api.create_discussion({"session_id": session_id, **new_discussion})
@@ -1199,6 +1203,7 @@ def setup_admin_commands(bot):
         discussion_id="The discussion to update (select from autocomplete)",
         title="New title",
         date="New date (YYYY-MM-DD)",
+        time="New start time in 24h format (HH:MM, e.g. 18:00)",
         location="New location",
         channel="The channel containing the club (defaults to current channel)"
     )
@@ -1207,6 +1212,7 @@ def setup_admin_commands(bot):
         discussion_id: str,
         title: str = None,
         date: str = None,
+        time: str = None,
         location: str = None,
         channel: discord.TextChannel = None
     ):
@@ -1227,9 +1233,9 @@ def setup_admin_commands(bot):
             await send_ephemeral(interaction,"❌ No active session found in that channel.")
             return
 
-        if not any([title, date, location]):
+        if not any([title, date, time, location]):
             await send_ephemeral(interaction,
-                "❌ Provide at least one field to update (title, date, or location)."
+                "❌ Provide at least one field to update (title, date, time, or location)."
             )
             return
 
@@ -1239,6 +1245,16 @@ def setup_admin_commands(bot):
             except ValueError:
                 await send_ephemeral(interaction,
                     "❌ Date must be in **YYYY-MM-DD** format (e.g., `2026-05-15`).",
+                    ephemeral=True
+                )
+                return
+
+        if time:
+            try:
+                datetime.strptime(time, "%H:%M")
+            except ValueError:
+                await send_ephemeral(interaction,
+                    "❌ Time must be in **HH:MM** 24h format (e.g., `18:00`).",
                     ephemeral=True
                 )
                 return
@@ -1256,10 +1272,18 @@ def setup_admin_commands(bot):
             await send_ephemeral(interaction,"❌ Discussion not found in the active session.")
             return
 
+        if date or time:
+            current_dt = datetime.fromisoformat(current["scheduled_at"])
+            new_date = date.strip() if date else current_dt.strftime("%Y-%m-%d")
+            new_time = time.strip() if time else current_dt.strftime("%H:%M")
+            scheduled_at = datetime.strptime(f"{new_date} {new_time}", "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc).isoformat()
+        else:
+            scheduled_at = current["scheduled_at"]
+
         updated = {
             "id": discussion_id,
             "title": title.strip() if title else current["title"],
-            "date": date.strip() if date else current["date"],
+            "scheduled_at": scheduled_at,
         }
         resolved_location = location.strip() if location else current.get("location")
         if resolved_location:
@@ -1267,7 +1291,7 @@ def setup_admin_commands(bot):
 
         try:
             bot.api.update_discussion(discussion_id, {k: v for k, v in updated.items() if k != "id"})
-            description = f"Updated **{updated['title']}** on {updated['date']}"
+            description = f"Updated **{updated['title']}** scheduled for {to_discord_timestamp(updated['scheduled_at'])}"
             if updated.get("location"):
                 description += f" at {updated['location']}"
             embed = create_embed(
@@ -1338,13 +1362,11 @@ def setup_admin_commands(bot):
     @app_commands.default_permissions(manage_guild=True)
     @app_commands.guild_only()
     @app_commands.describe(
-        default_time="Start time for created events in HH:MM 24h format (default: 18:00)",
         default_duration="Duration in hours for created events (default: 1.0)",
         channel="The channel containing the club (defaults to current channel)"
     )
     async def discussion_sync(
         interaction: discord.Interaction,
-        default_time: str = "18:00",
         default_duration: float = 1.0,
         channel: discord.TextChannel = None
     ):
@@ -1363,15 +1385,6 @@ def setup_admin_commands(bot):
             return
         if not club_data or not club_data.get("active_session"):
             await send_ephemeral(interaction,"❌ No active session found in that channel.")
-            return
-
-        try:
-            datetime.strptime(default_time, "%H:%M")
-        except ValueError:
-            await send_ephemeral(interaction,
-                "❌ default_time must be in **HH:MM** 24h format (e.g., `18:00`).",
-                ephemeral=True
-            )
             return
 
         if default_duration <= 0:
@@ -1418,12 +1431,12 @@ def setup_admin_commands(bot):
                 skipped.append(disc_title)
                 continue
 
-            # Parse the date; skip gracefully if it's not in the expected format.
-            raw_date = disc.get("date", "")
+            # Parse scheduled_at; skip gracefully if it's not in the expected format.
+            raw_scheduled_at = disc.get("scheduled_at", "")
             try:
-                start_dt = datetime.strptime(f"{raw_date} {default_time}", "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc)
+                start_dt = datetime.fromisoformat(raw_scheduled_at)
             except ValueError:
-                failed.append(f"{disc_title} (unparseable date: {raw_date!r})")
+                failed.append(f"{disc_title} (unparseable scheduled_at: {raw_scheduled_at!r})")
                 continue
 
             end_dt = start_dt + timedelta(hours=default_duration)

--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -3,13 +3,13 @@ Admin commands (version, server, club, member, session management)
 """
 import re
 import os
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta
 from typing import Literal
 import discord
 from discord import app_commands
 
 from utils.embeds import create_embed
-from utils.datetime_helpers import to_discord_timestamp, format_human_readable
+from utils.datetime_helpers import to_discord_timestamp, format_human_readable, parse_scheduled_at
 from api.bookclub_api import APIError, ResourceNotFoundError
 
 # Marker embedded in Discord event descriptions so discussion_sync can match them.
@@ -1152,7 +1152,7 @@ def setup_admin_commands(bot):
 
         session_id = club_data["active_session"]["id"]
         resolved_location = location.strip() if location and location.strip() else "Discord"
-        scheduled_at = datetime.strptime(f"{date} {time}", "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc).isoformat()
+        scheduled_at = parse_scheduled_at(date, time)
         new_discussion = {"title": title.strip(), "scheduled_at": scheduled_at, "location": resolved_location}
 
         try:
@@ -1164,7 +1164,7 @@ def setup_admin_commands(bot):
         disc_id = created_discussion.get("id")
 
         # Build timezone-aware datetimes for the Discord event (explicitly UTC)
-        start_dt = datetime.strptime(f"{date} {time}", "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc)
+        start_dt = datetime.fromisoformat(scheduled_at)
         end_dt = start_dt + timedelta(hours=duration)
 
         event_description = f"Book club discussion: {title.strip()}"
@@ -1276,7 +1276,7 @@ def setup_admin_commands(bot):
             current_dt = datetime.fromisoformat(current["scheduled_at"])
             new_date = date.strip() if date else current_dt.strftime("%Y-%m-%d")
             new_time = time.strip() if time else current_dt.strftime("%H:%M")
-            scheduled_at = datetime.strptime(f"{new_date} {new_time}", "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc).isoformat()
+            scheduled_at = parse_scheduled_at(new_date, new_time)
         else:
             scheduled_at = current["scheduled_at"]
 

--- a/cogs/session_commands.py
+++ b/cogs/session_commands.py
@@ -4,6 +4,8 @@ Session-related commands (book, due_date, session, discussions)
 import discord
 from discord import app_commands
 
+from utils.datetime_helpers import to_discord_timestamp
+
 from utils.embeds import create_embed
 from api.bookclub_api import ResourceNotFoundError
 
@@ -185,16 +187,17 @@ def setup_session_commands(bot):
             return
             
         discussions = session['discussions']
-        
-        # Sort discussions by date
-        discussions.sort(key=lambda x: x['date'])
-        
+
+        # Sort discussions by scheduled time
+        discussions.sort(key=lambda x: x['scheduled_at'])
+
         # Create fields for each discussion
         fields = []
         for i, discussion in enumerate(discussions):
+            formatted_when = to_discord_timestamp(discussion['scheduled_at'])
             fields.append({
                 "name": f"Discussion {i+1}: {discussion['title']}",
-                "value": f"**Date**: {discussion['date']}\n**Location**: {discussion.get('location', 'TBD')}",
+                "value": f"**When**: {formatted_when}\n**Location**: {discussion.get('location', 'TBD')}",
                 "inline": False
             })
         

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -1479,8 +1479,8 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
         self.session_with_discussions = {
             "id": "sess-1",
             "discussions": [
-                {"id": "disc-1", "title": "Chapters 1-5", "date": "2026-06-01", "location": "Discord"},
-                {"id": "disc-2", "title": "Chapters 6-10", "date": "2026-06-15"},
+                {"id": "disc-1", "title": "Chapters 1-5", "scheduled_at": "2026-06-01T18:00:00+00:00", "location": "Discord"},
+                {"id": "disc-2", "title": "Chapters 6-10", "scheduled_at": "2026-06-15T18:00:00+00:00"},
             ]
         }
 
@@ -1490,14 +1490,14 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.create_discussion.return_value = {
-            "id": "disc-new", "title": "Chapters 1-5", "date": "2026-06-01", "location": "Discord"
+            "id": "disc-new", "title": "Chapters 1-5", "scheduled_at": "2026-06-01T18:00:00+00:00", "location": "Discord"
         }
         interaction.guild.create_scheduled_event = AsyncMock()
         await self.commands["discussion_add"]["func"](
             interaction, title="Chapters 1-5", date="2026-06-01", time="18:00"
         )
         self.bot.api.create_discussion.assert_called_once_with(
-            {"session_id": "sess-1", "title": "Chapters 1-5", "date": "2026-06-01", "time": "18:00:00", "location": "Discord"}
+            {"session_id": "sess-1", "title": "Chapters 1-5", "scheduled_at": "2026-06-01T18:00:00+00:00", "location": "Discord"}
         )
         interaction.guild.create_scheduled_event.assert_called_once()
         call_kwargs = interaction.guild.create_scheduled_event.call_args.kwargs
@@ -1507,7 +1507,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
     async def test_discussion_add_embeds_id_in_event_description(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
-        self.bot.api.create_discussion.return_value = {"id": "disc-abc", "title": "Intro", "date": "2026-06-01"}
+        self.bot.api.create_discussion.return_value = {"id": "disc-abc", "title": "Intro", "scheduled_at": "2026-06-01T18:00:00+00:00"}
         interaction.guild.create_scheduled_event = AsyncMock()
         await self.commands["discussion_add"]["func"](
             interaction, title="Intro", date="2026-06-01", time="18:00"
@@ -1518,7 +1518,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
     async def test_discussion_add_event_created_without_id_when_response_lacks_id(self):
         interaction = _make_interaction(user_id="111")
         self.bot.api.find_club_in_channel.return_value = self.club
-        self.bot.api.create_discussion.return_value = {"title": "Intro", "date": "2026-06-01"}
+        self.bot.api.create_discussion.return_value = {"title": "Intro", "scheduled_at": "2026-06-01T18:00:00+00:00"}
         interaction.guild.create_scheduled_event = AsyncMock()
         await self.commands["discussion_add"]["func"](
             interaction, title="Intro", date="2026-06-01", time="18:00"
@@ -1537,7 +1537,7 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
             interaction, title="Intro", date="2026-06-01", time="19:00", location="Library"
         )
         self.bot.api.create_discussion.assert_called_once_with(
-            {"session_id": "sess-1", "title": "Intro", "date": "2026-06-01", "time": "19:00:00", "location": "Library"}
+            {"session_id": "sess-1", "title": "Intro", "scheduled_at": "2026-06-01T19:00:00+00:00", "location": "Library"}
         )
         call_kwargs = interaction.guild.create_scheduled_event.call_args.kwargs
         self.assertEqual(call_kwargs["location"], "Library")
@@ -1675,9 +1675,34 @@ class TestDiscussionCommands(unittest.IsolatedAsyncioTestCase):
         )
         self.bot.api.update_discussion.assert_called_once_with(
             "disc-1",
-            {"title": "Updated Title", "date": "2026-06-01", "location": "Discord"}
+            {"title": "Updated Title", "scheduled_at": "2026-06-01T18:00:00+00:00", "location": "Discord"}
         )
         self.assertIn("embed", interaction.followup.send.call_args.kwargs)
+
+    async def test_discussion_update_date_and_time(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        self.bot.api.get_session.return_value = self.session_with_discussions
+        self.bot.api.update_discussion.return_value = {"success": True}
+        await self.commands["discussion_update"]["func"](
+            interaction, discussion_id="disc-1", date="2026-07-04", time="20:30"
+        )
+        self.bot.api.update_discussion.assert_called_once_with(
+            "disc-1",
+            {"title": "Chapters 1-5", "scheduled_at": "2026-07-04T20:30:00+00:00", "location": "Discord"}
+        )
+
+    async def test_discussion_update_invalid_time(self):
+        interaction = _make_interaction(user_id="111")
+        self.bot.api.find_club_in_channel.return_value = self.club
+        await self.commands["discussion_update"]["func"](
+            interaction, discussion_id="disc-1", time="8pm"
+        )
+        if interaction.followup.send.call_args.args:
+            self.assertIn("❌", interaction.followup.send.call_args.args[0])
+        else:
+            self.assertIn("embed", interaction.followup.send.call_args.kwargs)
+        self.bot.api.update_discussion.assert_not_called()
 
     async def test_discussion_update_no_args(self):
         interaction = _make_interaction(user_id="111")
@@ -1836,8 +1861,8 @@ class TestDiscussionSync(unittest.IsolatedAsyncioTestCase):
         self.bot, self.commands = _make_bot()
         self.club = _club_with_admin("111")
         self.discussions = [
-            {"id": "disc-1", "title": "Chapters 1-5", "date": "2026-06-01", "location": "Discord"},
-            {"id": "disc-2", "title": "Chapters 6-10", "date": "2026-06-15"},
+            {"id": "disc-1", "title": "Chapters 1-5", "scheduled_at": "2026-06-01T18:00:00+00:00", "location": "Discord"},
+            {"id": "disc-2", "title": "Chapters 6-10", "scheduled_at": "2026-06-15T18:00:00+00:00"},
         ]
 
     def _make_event(self, description=""):
@@ -1896,7 +1921,7 @@ class TestDiscussionSync(unittest.IsolatedAsyncioTestCase):
 
     async def test_sync_skips_discussions_with_unparseable_date(self):
         interaction = _make_interaction(user_id="111")
-        bad_discussion = {"id": "disc-bad", "title": "Bad Date", "date": "sometime in June"}
+        bad_discussion = {"id": "disc-bad", "title": "Bad Date", "scheduled_at": "sometime in June"}
         self.bot.api.find_club_in_channel.return_value = self.club
         self.bot.api.get_session.return_value = {"discussions": [bad_discussion]}
         interaction.guild.fetch_scheduled_events = AsyncMock(return_value=[])
@@ -1929,16 +1954,6 @@ class TestDiscussionSync(unittest.IsolatedAsyncioTestCase):
         club_no_session["active_session"] = None
         self.bot.api.find_club_in_channel.return_value = club_no_session
         await self.commands["discussion_sync"]["func"](interaction)
-        # Check for error in either positional or keyword arguments
-        if interaction.followup.send.call_args.args:
-            self.assertIn("❌", interaction.followup.send.call_args.args[0])
-        else:
-            self.assertIn("embed", interaction.followup.send.call_args.kwargs)
-
-    async def test_sync_invalid_default_time(self):
-        interaction = _make_interaction(user_id="111")
-        self.bot.api.find_club_in_channel.return_value = self.club
-        await self.commands["discussion_sync"]["func"](interaction, default_time="6pm")
         # Check for error in either positional or keyword arguments
         if interaction.followup.send.call_args.args:
             self.assertIn("❌", interaction.followup.send.call_args.args[0])
@@ -1994,8 +2009,8 @@ class TestDiscussionAutocomplete(unittest.IsolatedAsyncioTestCase):
         }
         interaction.client.api.get_session.return_value = {
             "discussions": [
-                {"id": "disc-1", "title": "Chapters 1-5", "date": "2026-06-01"},
-                {"id": "disc-2", "title": "Chapters 6-10", "date": "2026-06-15"},
+                {"id": "disc-1", "title": "Chapters 1-5", "scheduled_at": "2026-06-01T18:00:00+00:00"},
+                {"id": "disc-2", "title": "Chapters 6-10", "scheduled_at": "2026-06-15T18:00:00+00:00"},
             ]
         }
 
@@ -2016,8 +2031,8 @@ class TestDiscussionAutocomplete(unittest.IsolatedAsyncioTestCase):
         }
         interaction.client.api.get_session.return_value = {
             "discussions": [
-                {"id": "disc-1", "title": "Chapters 1-5", "date": "2026-06-01"},
-                {"id": "disc-2", "title": "Final meeting", "date": "2026-07-01"},
+                {"id": "disc-1", "title": "Chapters 1-5", "scheduled_at": "2026-06-01T18:00:00+00:00"},
+                {"id": "disc-2", "title": "Final meeting", "scheduled_at": "2026-07-01T18:00:00+00:00"},
             ]
         }
 

--- a/tests/test_bookclub_api.py
+++ b/tests/test_bookclub_api.py
@@ -440,7 +440,7 @@ class TestBookClubAPI(unittest.TestCase):
             "club": {"id": "club-1", "name": "Test Club"},
             "book": {"id": 1, "title": "Test Book", "author": "Test Author"},
             "due_date": "2025-04-15",
-            "discussions": [{"id": "disc-1", "title": "Chapter 1-3", "date": "2025-04-01"}],
+            "discussions": [{"id": "disc-1", "title": "Chapter 1-3", "scheduled_at": "2025-04-01T18:00:00+00:00"}],
             "shame_list": []
         }
         mock_response.raise_for_status = Mock()
@@ -481,7 +481,7 @@ class TestBookClubAPI(unittest.TestCase):
             "book": {"title": "New Book", "author": "Author Name"},
             "due_date": "2025-05-15",
             "discussions": [
-                {"title": "First Discussion", "date": "2025-05-01"}
+                {"title": "First Discussion", "scheduled_at": "2025-05-01T18:00:00+00:00"}
             ]
         }
         
@@ -1197,8 +1197,7 @@ class TestBookClubAPI(unittest.TestCase):
             "id": "discussion-new",
             "session_id": "session-1",
             "title": "Chapters 1-3",
-            "date": "2025-05-01",
-            "time": "18:00:00",
+            "scheduled_at": "2025-05-01T18:00:00+00:00",
             "location": "Library"
         }
         mock_response.raise_for_status = Mock()
@@ -1207,8 +1206,7 @@ class TestBookClubAPI(unittest.TestCase):
         discussion_data = {
             "session_id": "session-1",
             "title": "Chapters 1-3",
-            "date": "2025-05-01",
-            "time": "18:00:00",
+            "scheduled_at": "2025-05-01T18:00:00+00:00",
             "location": "Library"
         }
 
@@ -1234,7 +1232,7 @@ class TestBookClubAPI(unittest.TestCase):
         mock_post.return_value = mock_response
 
         with self.assertRaises(ResourceNotFoundError):
-            self.api.create_discussion({"session_id": "missing-session", "title": "Chapters 1-3", "date": "2025-05-01"})
+            self.api.create_discussion({"session_id": "missing-session", "title": "Chapters 1-3", "scheduled_at": "2025-05-01T18:00:00+00:00"})
 
     @patch('requests.put')
     def test_update_discussion(self, mock_put):
@@ -1243,13 +1241,13 @@ class TestBookClubAPI(unittest.TestCase):
         mock_response.json.return_value = {
             "id": "discussion-123",
             "title": "Updated Discussion",
-            "date": "2025-05-10",
+            "scheduled_at": "2025-05-10T18:00:00+00:00",
             "location": "Online"
         }
         mock_response.raise_for_status = Mock()
         mock_put.return_value = mock_response
 
-        update_data = {"title": "Updated Discussion", "date": "2025-05-10", "location": "Online"}
+        update_data = {"title": "Updated Discussion", "scheduled_at": "2025-05-10T18:00:00+00:00", "location": "Online"}
 
         result = self.api.update_discussion("discussion-123", update_data)
 

--- a/tests/test_session_commands.py
+++ b/tests/test_session_commands.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, MagicMock, AsyncMock
 
 from cogs.session_commands import setup_session_commands
 from api.bookclub_api import ResourceNotFoundError
+from utils.datetime_helpers import to_discord_timestamp
 
 
 class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
@@ -35,13 +36,13 @@ class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
                 'discussions': [
                     {
                         'id': 'discussion-1',
-                        'date': '2025-04-15',
+                        'scheduled_at': '2025-04-15T18:00:00+00:00',
                         'title': 'First Discussion',
                         'location': 'Room 101'
                     },
                     {
                         'id': 'discussion-2',
-                        'date': '2025-04-20',
+                        'scheduled_at': '2025-04-20T18:00:00+00:00',
                         'title': 'Second Discussion',
                         'location': 'Room 202'
                     }
@@ -245,8 +246,11 @@ class TestSessionCommands(unittest.IsolatedAsyncioTestCase):
         # Verify defer was called
         interaction.response.defer.assert_called_once()
 
-        # Verify followup.send was called
+        # Verify followup.send was called with an embed reflecting scheduled_at
         interaction.followup.send.assert_called_once()
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        self.assertIn(to_discord_timestamp("2025-04-15T18:00:00+00:00"), embed.fields[0].value)
+        self.assertIn(to_discord_timestamp("2025-04-20T18:00:00+00:00"), embed.fields[1].value)
 
     async def test_discussions_command_no_discussions(self):
         """Test the discussions command when no discussions exist"""

--- a/utils/datetime_helpers.py
+++ b/utils/datetime_helpers.py
@@ -1,7 +1,13 @@
 """
-Helpers for converting stored ISO 8601 timestamps into user-facing formats.
+Helpers for converting between user-supplied date/time strings and the
+ISO 8601 scheduled_at timestamps stored by the API.
 """
-from datetime import datetime
+from datetime import datetime, timezone
+
+
+def parse_scheduled_at(date_str: str, time_str: str) -> str:
+    """Combines a 'YYYY-MM-DD' date and 'HH:MM' time into a UTC scheduled_at ISO string."""
+    return datetime.strptime(f"{date_str} {time_str}", "%Y-%m-%d %H:%M").replace(tzinfo=timezone.utc).isoformat()
 
 
 def to_discord_timestamp(iso_str: str, style: str = "F") -> str:

--- a/utils/datetime_helpers.py
+++ b/utils/datetime_helpers.py
@@ -1,0 +1,25 @@
+"""
+Helpers for converting stored ISO 8601 timestamps into user-facing formats.
+"""
+from datetime import datetime
+
+
+def to_discord_timestamp(iso_str: str, style: str = "F") -> str:
+    """Converts an ISO 8601 string into a Discord timestamp tag.
+
+    Discord renders <t:epoch:style> client-side in each viewer's own
+    local timezone, so this is the preferred way to show scheduled_at
+    in embeds and messages.
+    """
+    dt = datetime.fromisoformat(iso_str)
+    return f"<t:{int(dt.timestamp())}:{style}>"
+
+
+def format_human_readable(iso_str: str) -> str:
+    """Formats an ISO 8601 string as plain text, e.g. 'June 1, 2026 at 6:00 PM UTC'.
+
+    Use this where Discord timestamp tags aren't rendered, such as
+    autocomplete choice labels.
+    """
+    dt = datetime.fromisoformat(iso_str)
+    return dt.strftime("%B %-d, %Y at %-I:%M %p UTC")


### PR DESCRIPTION
## Summary
- Replaces separate `date`/`time` fields on discussions with a single `scheduled_at` ISO 8601 timestamp across `api/bookclub_api.py`, `cogs/admin_commands.py`, and `cogs/session_commands.py`.
- Adds `utils/datetime_helpers.py` with `to_discord_timestamp()` (Discord-native `<t:...:F>` tags, rendered per-viewer in their own local time) and `format_human_readable()` for autocomplete labels.
- `discussion_update` now supports updating just date or just time, preserving the other component from the existing `scheduled_at`.
- Removed `discussion_sync`'s now-redundant `default_time` parameter since time is carried in `scheduled_at`.

## Test plan
- [ ] `make test` passes locally
- [ ] `/discussion_add` creates a discussion with correct `scheduled_at` and Discord scheduled event
- [ ] `/discussion_update` with only `date` or only `time` preserves the other component
- [ ] `/discussions` embed renders Discord timestamps correctly
- [ ] `/discussion_sync` still creates events from `scheduled_at`

Follow-up tracked separately: per-user timezone preference (https://app.notion.com/p/37def355462381d6be7cff78e1499d04)